### PR TITLE
substrate: fix nomination to a single validator

### DIFF
--- a/packages/staking-cli/package.json
+++ b/packages/staking-cli/package.json
@@ -33,7 +33,7 @@
     "@chorus-one/signer-fireblocks": "^1.0.0",
     "@chorus-one/signer-local": "^1.0.0",
     "@chorus-one/solana": "^1.0.0",
-    "@chorus-one/substrate": "^1.0.0",
+    "@chorus-one/substrate": "^1.0.1",
     "@chorus-one/ton": "^1.0.0",
     "@chorus-one/utils": "^1.0.0",
     "@commander-js/extra-typings": "^11.1.0",

--- a/packages/substrate/package.json
+++ b/packages/substrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/substrate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "All-in-one toolkit for building staking dApps on Substrate Network SDK blockchains(Polkadot, Kusama, etc.)",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json"

--- a/packages/substrate/src/staker.ts
+++ b/packages/substrate/src/staker.ts
@@ -344,6 +344,9 @@ export class SubstrateStaker {
       throw new Error(`unable to find method ${txCall.section}.${txCall.method}`)
     }
 
+    if (params.length === 1) {
+      return { tx: api.tx[txCall.section][txCall.method](params) }
+    }
     return { tx: api.tx[txCall.section][txCall.method](...params) }
   }
 


### PR DESCRIPTION
The problem occurs when a single validator is being passed in the Array and `...params` resolves it to single string which polkadot api doesn't expect

Tested with:
```
npm run staking-cli -- substrate tx delegate 0.1
npm run staking-cli -- substrate tx nominate 0.1
npm run staking-cli -- substrate tx bond-extra 0.1
npm run staking-cli -- substrate tx unbond 0.1
npm run staking-cli -- substrate tx withdraw
```