### PR TITLE
Add referrer field for TON staking tx

### DIFF
--- a/book/build-your-staking-dapp/ton/ton-pool/methods.md
+++ b/book/build-your-staking-dapp/ton/ton-pool/methods.md
@@ -18,7 +18,7 @@ Staking tokens supports the network's operations and earns rewards for the deleg
 
 ### How to Use
 
-To build a staking transaction, you need to provide the validator address pair, the staking amount (in TON), and optionally, a Unix timestamp indicating when the transaction expires.
+To build a staking transaction, you need to provide the validator address pair, and the staking amount (in TON). Optionally, you can also specify a referrer address for tracking purposes, and a Unix timestamp indicating when the transaction expires.
 
 ### Example
 
@@ -29,7 +29,8 @@ const { tx } = await staker.buildStakeTx({
     'kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o'
   ],
   amount: '2', // 2 TON
-  validUntil: Math.floor(Date.now() / 1000) + 3600 // Optional, expires in 1 hour
+  validUntil: Math.floor(Date.now() / 1000) + 3600, // Optional, expires in 1 hour
+  referrer: 'Telegram' // Optional, unique referrer string for tracking
 })
 ```
 

--- a/book/docs/classes/ton_src.TonPoolStaker.md
+++ b/book/docs/classes/ton_src.TonPoolStaker.md
@@ -178,6 +178,7 @@ to stake to automatically.
 | `params` | `Object` | Parameters for building the transaction |
 | `params.validatorAddressPair` | [`string`, `string`] | The validator address pair to stake to |
 | `params.amount` | `string` | The amount to stake, specified in `TON` |
+| `params.referrer?` | `string` | (Optional) The address of the referrer. This is used to track the origin of transactions, providing insights into which sources or campaigns are driving activity. This can be useful for analytics and optimizing user acquisition strategies |
 | `params.validUntil?` | `number` | (Optional) The Unix timestamp when the transaction expires |
 
 ### Returns


### PR DESCRIPTION
Adding referrer for TON tx for tracking.

To parse those fields from transactions, you can use:
```typescript
const txStatus = await this.getTxStatus({
  address: 'kQDeHoxmpJ6dzzl7KyHDQuOSkwvEnXMcs-8gMCJOSo-IpTrj',
  txHash: '37fd26a86aafd6fb05953655a0ecbe7ba5f1955002f105127359555f5151e733'
})

const body = txStatus.receipt?.outMessages.get(0)?.body.beginParse()
const op = body.loadUint(32)
const queryId = body.loadUint(64)
const gas = body.loadCoins()
const referrer = body.loadStringTail()
console.log({
  op,
  queryId,
  gas,
  referrer
})
``` 

Output:
```js
{
  op: 2077040623,
  queryId: 4090730133165079,
  gas: 100000n,
  referrer: 'Hello TON!!!'
}
```

Tx:

https://testnet.tonviewer.com/transaction/37fd26a86aafd6fb05953655a0ecbe7ba5f1955002f105127359555f5151e733?section=trace