### PR TITLE
balance stake for both ton pool contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3808,8 +3808,9 @@
       }
     },
     "node_modules/@ton/core": {
-      "version": "0.56.3",
-      "license": "MIT",
+      "version": "0.59.1",
+      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.59.1.tgz",
+      "integrity": "sha512-SxFBAvutYJaIllTkv82vbHTJhJI6NxzqUhi499CDEjJEZ9i6i9lHJiK2df4dlLAb/4SiWX6+QUzESkK4DEdnCw==",
       "peer": true,
       "dependencies": {
         "symbol.inspect": "1.0.1"
@@ -3819,26 +3820,29 @@
       }
     },
     "node_modules/@ton/crypto": {
-      "version": "3.2.0",
-      "license": "MIT",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
+      "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
       "peer": true,
       "dependencies": {
-        "@ton/crypto-primitives": "2.0.0",
+        "@ton/crypto-primitives": "2.1.0",
         "jssha": "3.2.0",
         "tweetnacl": "1.0.3"
       }
     },
     "node_modules/@ton/crypto-primitives": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
+      "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
       "peer": true,
       "dependencies": {
         "jssha": "3.2.0"
       }
     },
     "node_modules/@ton/ton": {
-      "version": "13.11.2",
-      "license": "MIT",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/ton/-/ton-15.1.0.tgz",
+      "integrity": "sha512-almetcfTu7jLjcNcEEPB7wAc8yl90ES1M//sOr1QE+kv7RbmEvMkaPSc7kFxzs10qrjIPKxlodBJlMSWP5LuVQ==",
       "dependencies": {
         "axios": "^1.6.7",
         "dataloader": "^2.0.0",
@@ -3847,7 +3851,7 @@
         "zod": "^3.21.4"
       },
       "peerDependencies": {
-        "@ton/core": ">=0.56.0",
+        "@ton/core": ">=0.59.0",
         "@ton/crypto": ">=3.2.0"
       }
     },
@@ -6889,7 +6893,8 @@
     },
     "node_modules/jssha": {
       "version": "3.2.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
+      "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
       "peer": true,
       "engines": {
         "node": "*"
@@ -8474,7 +8479,8 @@
     },
     "node_modules/symbol.inspect": {
       "version": "1.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/symbol.inspect/-/symbol.inspect-1.0.1.tgz",
+      "integrity": "sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ=="
     },
     "node_modules/teslabot": {
       "version": "1.5.0",
@@ -9410,7 +9416,7 @@
         "@chorus-one/signer": "^1.0.0",
         "@chorus-one/utils": "^1.0.0",
         "@noble/curves": "^1.4.0",
-        "@ton/ton": "^13.11.2",
+        "@ton/ton": "^15.1.0",
         "axios": "^1.7.2",
         "tonweb-mnemonic": "^1.0.1"
       }

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -146,7 +146,7 @@ async function runTx (
         }
         const stakingPoolAddressPair: [string, string] = [config.validatorAddress, config.validatorAddress2]
         const poolsInfo = await tonStaker.getPoolAddressForStake({ validatorAddressPair: stakingPoolAddressPair })
-        const poolIndex = stakingPoolAddressPair.findIndex((addr: string) => addr === poolsInfo.SelectedPoolAddress)
+        const poolIndex = stakingPoolAddressPair.findIndex((addr: string) => addr === poolsInfo.selectedPoolAddress)
         if (poolIndex === -1) {
           cmd.error('validator address not found in the pool', { exitCode: 1, code: `${msgType}.tx.abort` })
         }

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -144,11 +144,13 @@ async function runTx (
           cmd.error('second validator address is required for TON Pool', { exitCode: 1, code: `${msgType}.tx.abort` })
         }
         const validatorAddressPair: [string, string] = [config.validatorAddress, config.validatorAddress2]
+        const poolsInfo = await tonStaker.getPoolAddressForStake({ validatorAddressPair })
+        const validatorIndex = validatorAddressPair.findIndex((addr: string) => addr === poolsInfo.SelectedPoolAddress)
+        if (validatorIndex === -1) {
+          cmd.error('validator address not found in the pool', { exitCode: 1, code: `${msgType}.tx.abort` })
+        }
 
-        const validatorToDelegate = await tonStaker.getPoolAddressForStake({ validatorAddressPair })
-        const validatorIndex = validatorToDelegate === config.validatorAddress ? 1 : 2
-
-        console.log('Delegating to validator #' + validatorIndex + ': ' + validatorToDelegate)
+        console.log('Delegating to validator #' + (validatorIndex+1) + ': ' + validatorAddressPair[validatorIndex])
 
         unsignedTx = (
           await tonStaker.buildStakeTx({

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -144,18 +144,18 @@ async function runTx (
         if (!config.validatorAddress2) {
           cmd.error('second validator address is required for TON Pool', { exitCode: 1, code: `${msgType}.tx.abort` })
         }
-        const validatorAddressPair: [string, string] = [config.validatorAddress, config.validatorAddress2]
-        const poolsInfo = await tonStaker.getPoolAddressForStake({ validatorAddressPair })
-        const validatorIndex = validatorAddressPair.findIndex((addr: string) => addr === poolsInfo.SelectedPoolAddress)
-        if (validatorIndex === -1) {
+        const stakingPoolAddressPair: [string, string] = [config.validatorAddress, config.validatorAddress2]
+        const poolsInfo = await tonStaker.getPoolAddressForStake({ validatorAddressPair: stakingPoolAddressPair })
+        const poolIndex = stakingPoolAddressPair.findIndex((addr: string) => addr === poolsInfo.SelectedPoolAddress)
+        if (poolIndex === -1) {
           cmd.error('validator address not found in the pool', { exitCode: 1, code: `${msgType}.tx.abort` })
         }
 
-        console.log('Delegating to validator #' + (validatorIndex+1) + ': ' + validatorAddressPair[validatorIndex])
+        console.log('Delegating to pool #' + (poolIndex+1) + ': ' + stakingPoolAddressPair[poolIndex])
 
         unsignedTx = (
           await tonStaker.buildStakeTx({
-            validatorAddressPair,
+            validatorAddressPair: stakingPoolAddressPair,
             amount: arg[0] // amount
           })
         ).tx

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -121,6 +121,7 @@ async function runTx (
       {
         delegator: config.delegatorAddress,
         validatorAddress: config.validatorAddress,
+        validatorAddress2: config.validatorAddress2,
         messageType: msgType,
         args: arg,
         broadcast: broadcastEnabled

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -35,7 +35,7 @@
     "@chorus-one/signer": "^1.0.0",
     "@chorus-one/utils": "^1.0.0",
     "@noble/curves": "^1.4.0",
-    "@ton/ton": "^13.11.2",
+    "@ton/ton": "^15.1.0",
     "axios": "^1.7.2",
     "tonweb-mnemonic": "^1.0.1"
   }

--- a/packages/ton/src/TonBaseStaker.ts
+++ b/packages/ton/src/TonBaseStaker.ts
@@ -12,7 +12,6 @@ import type {
 import {
   toNano,
   fromNano,
-  TonClient,
   WalletContractV4,
   internal,
   MessageRelaxed,
@@ -22,6 +21,7 @@ import {
   beginCell,
   storeMessage
 } from '@ton/ton'
+import { TonClient } from './TonClient'
 import { createWalletTransferV4, externalMessage, sign } from './tx'
 import * as tonMnemonic from 'tonweb-mnemonic'
 import { ed25519 } from '@noble/curves/ed25519'

--- a/packages/ton/src/TonClient.ts
+++ b/packages/ton/src/TonClient.ts
@@ -1,0 +1,46 @@
+import {
+  TonClient as NativeTonClient,
+  Cell,
+} from '@ton/ton'
+import axios from "axios";
+import { z } from 'zod';
+
+const configParamCodec = z.object({
+    ok: z.boolean(),
+    result: z.object({
+        '@type': z.string(),
+        config: z.object({
+            '@type': z.string(),
+            bytes: z.string(),
+        }),
+        '@extra': z.string(),
+    })
+});
+
+export class TonClient extends NativeTonClient {
+
+    async getConfigParam (config_id: number): Promise<Cell> {
+        const url = new URL(this.parameters.endpoint)
+        const base = url.pathname.split('/').slice(0, -1).join('/')
+        url.pathname = base + '/getConfigParam'
+        url.searchParams.set('config_id', config_id.toString())
+
+        const r = await axios.get(url.toString())
+        if (r.status !== 200) {
+            throw Error('Unable to fetch config param, error: ' + r.status + ' ' + r.statusText)
+        }
+
+        const configParam = configParamCodec.safeParse(r.data)
+        if (!configParam.success) {
+            throw Error('Unable to parse config param, error: ' + JSON.stringify(configParam.error))
+        }
+
+        const paramBytes = configParam.data?.result.config.bytes
+        if (paramBytes === undefined) {
+            throw Error('Failed to get config param bytes')
+        }
+
+        return Cell.fromBoc(Buffer.from(paramBytes, 'base64'))[0];
+    }
+}
+

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -24,7 +24,7 @@ export class TonPoolStaker extends TonBaseStaker {
     validUntil?: number
   }): Promise<{ tx: UnsignedTx }> {
     const { validatorAddressPair, amount, validUntil, referrer } = params
-    const poolAddress = (await this.getPoolAddressForStake({ validatorAddressPair })).SelectedPoolAddress
+    const poolAddress = (await this.getPoolAddressForStake({ validatorAddressPair })).selectedPoolAddress
 
     // ensure the address is for the right network
     this.checkIfAddressTestnetFlagMatches(poolAddress)
@@ -191,7 +191,7 @@ export class TonPoolStaker extends TonBaseStaker {
         this.getPastElections('Ef8zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM0vF'),
     ])
 
-    const [ poolOneBalance, poolTwoBalance ] = [poolOneStatus.Balance, poolTwoStatus.Balance]
+    const [ poolOneBalance, poolTwoBalance ] = [poolOneStatus.balance, poolTwoStatus.balance]
 
     // simple sanity validation
     if (elections.length == 0) {
@@ -206,9 +206,9 @@ export class TonPoolStaker extends TonBaseStaker {
     const selectedPoolIndex = TonPoolStaker.selectPool(minStake, [poolOneBalance, poolTwoBalance])
 
     return {
-        SelectedPoolAddress: validatorAddressPair[selectedPoolIndex],
-        MinStake: minStake,
-        PoolStakes: [poolOneBalance, poolTwoBalance]
+        selectedPoolAddress: validatorAddressPair[selectedPoolIndex],
+        minStake: minStake,
+        poolStakes: [poolOneBalance, poolTwoBalance]
     }
   }
 
@@ -218,11 +218,11 @@ export class TonPoolStaker extends TonBaseStaker {
     const res = await provider.get('get_pool_status', []);
 
     return {
-      Balance: res.stack.readBigNumber(),
-      BalanceSent: res.stack.readBigNumber(),
-      BalancePendingDeposits: res.stack.readBigNumber(),
-      BalancePendingWithdrawals: res.stack.readBigNumber(),
-      BalanceWithdraw: res.stack.readBigNumber()
+      balance: res.stack.readBigNumber(),
+      balanceSent: res.stack.readBigNumber(),
+      balancePendingDeposits: res.stack.readBigNumber(),
+      balancePendingWithdrawals: res.stack.readBigNumber(),
+      balanceWithdraw: res.stack.readBigNumber()
     }
   }
 

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -289,7 +289,7 @@ export class TonPoolStaker extends TonBaseStaker {
           return 1; // fill pool 2 to meet minStake
       }
 
-      // both pools have reached minStake, so allocae to the one with the lower balance
+      // both pools have reached minStake, so allocate to the one with the lower balance
       return balancePool1 <= balancePool2 ? 0 : 1;
   }
 }

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -279,7 +279,7 @@ export class TonPoolStaker extends TonBaseStaker {
     }
 
     // return elections sorted by id (bigint) in descending order
-    return elections.sort((a, b) => (a > b ? 1 : -1));
+    return elections.sort((a, b) => (a.id > b.id ? -1 : 1));
   }
 
   /** @ignore */

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -295,8 +295,8 @@ export class TonPoolStaker extends TonBaseStaker {
 
       // prioritize filling a pool that hasn't reached the minStake
       if (!hasReachedMinStake(balancePool1) && !hasReachedMinStake(balancePool2)) {
-          // if neither pool has reached minStake, prioritize the one with the smaller balance
-          return balancePool1 <= balancePool2 ? 0 : 1;
+          // if neither pool has reached minStake, prioritize the one with the higher balance
+          return balancePool1 >= balancePool2 ? 0 : 1;
       } else if (!hasReachedMinStake(balancePool1)) {
           return 0; // fill pool 1 to meet minStake
       } else if (!hasReachedMinStake(balancePool2)) {

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -289,7 +289,7 @@ export class TonPoolStaker extends TonBaseStaker {
           return 1; // fill pool 2 to meet minStake
       }
 
-      // both pools have reached minStake, balance them until they reach maxStake
+      // both pools have reached minStake, so allocae to the one with the lower balance
       return balancePool1 <= balancePool2 ? 0 : 1;
   }
 }

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -74,6 +74,13 @@ export interface PoolStatus {
     BalanceWithdraw: bigint;
 }
 
+export interface GetPoolAddressForStakeResponse {
+    SelectedPoolAddress: string;
+    MinStake: bigint;
+    MaxStake: bigint;
+    PoolStakes: [biginy, bigint];
+}
+
 export interface AddressDerivationConfig {
   walletContractVersion: number
   workchain: number

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -77,7 +77,6 @@ export interface PoolStatus {
 export interface GetPoolAddressForStakeResponse {
     SelectedPoolAddress: string;
     MinStake: bigint;
-    MaxStake: bigint;
     PoolStakes: [biginy, bigint];
 }
 

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -49,6 +49,31 @@ export interface PoolData {
   min_nominator_stake: bigint
 }
 
+// reference: https://github.com/ton-core/ton/blob/55c576dfc5976e1881180ee271ba8ec62d3f13d4/src/elector/ElectorContract.ts#L70C11-L70C27
+export interface Election {
+    id: number;
+    unfreezeAt: number;
+    stakeHeld: number;
+    validatorSetHash: bigint;
+    totalStake: bigint;
+    bonuses: bigint;
+    frozen: Map<string, FrozenSet>;
+}
+
+export interface FrozenSet {
+    address: Address;
+    weight: bigint;
+    stake: bigint;
+}
+
+export interface PoolStatus {
+    Balance: bigint;
+    BalanceSent: bigint;
+    BalancePendingDeposits: bigint;
+    BalancePendingWithdrawals: bigint;
+    BalanceWithdraw: bigint;
+}
+
 export interface AddressDerivationConfig {
   walletContractVersion: number
   workchain: number

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -67,17 +67,17 @@ export interface FrozenSet {
 }
 
 export interface PoolStatus {
-    Balance: bigint;
-    BalanceSent: bigint;
-    BalancePendingDeposits: bigint;
-    BalancePendingWithdrawals: bigint;
-    BalanceWithdraw: bigint;
+    balance: bigint;
+    balanceSent: bigint;
+    balancePendingDeposits: bigint;
+    balancePendingWithdrawals: bigint;
+    balanceWithdraw: bigint;
 }
 
 export interface GetPoolAddressForStakeResponse {
-    SelectedPoolAddress: string;
-    MinStake: bigint;
-    PoolStakes: [biginy, bigint];
+    selectedPoolAddress: string;
+    minStake: bigint;
+    poolStakes: [biginy, bigint];
 }
 
 export interface AddressDerivationConfig {

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -24,6 +24,6 @@ describe('TonPoolStaker', () => {
   })
 
   it('should throw an error if both pools have reached maxStake', () => {
-      expect(() => TonPoolStaker.selectPool(200n, 1000n, [1000n, 1000n])).to.throw("Both pools have reached their maximum stake limits.");
+      expect(() => TonPoolStaker.selectPool(200n, 1000n, [1000n, 1000n])).to.throw("Both pools have reached their maximum stake limits");
   })
 })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -4,26 +4,17 @@ import { expect } from 'chai'
 
 describe('TonPoolStaker', () => {
   it('should prioritize the pool that has not reached minStake', () => {
-      const result = TonPoolStaker.selectPool(200n, 1000n, [100n, 300n]);
+      const result = TonPoolStaker.selectPool(200n, [100n, 300n]);
       expect(result).to.equal(0); // Pool 1 needs to reach minStake
   })
 
   it('should prioritize the pool with a higher balance if both are below minStake', () => {
-      const result = TonPoolStaker.selectPool(200n, 1000n, [100n, 150n]);
+      const result = TonPoolStaker.selectPool(200n, [100n, 150n]);
       expect(result).to.equal(1); // Pool 2 has a higher balance
   })
 
-  it('should balance the pools if both have reached minStake but are below maxStake', () => {
-      const result = TonPoolStaker.selectPool(200n, 1000n, [400n, 300n]);
+  it('should balance the pools if both have reached minStake', () => {
+      const result = TonPoolStaker.selectPool(200n, [400n, 300n]);
       expect(result).to.equal(1); // Pool 2 has a smaller balance
-  })
-
-  it('should add to the pool that has not reached maxStake', () => {
-      const result = TonPoolStaker.selectPool(200n, 1000n, [1000n, 800n]);
-      expect(result).to.equal(1); // Pool 2 has not reached maxStake
-  })
-
-  it('should throw an error if both pools have reached maxStake', () => {
-      expect(() => TonPoolStaker.selectPool(200n, 1000n, [1000n, 1000n])).to.throw("Both pools have reached their maximum stake limits");
   })
 })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -8,9 +8,9 @@ describe('TonPoolStaker', () => {
       expect(result).to.equal(0); // Pool 1 needs to reach minStake
   })
 
-  it('should prioritize the pool with a smaller balance if both are below minStake', () => {
+  it('should prioritize the pool with a higher balance if both are below minStake', () => {
       const result = TonPoolStaker.selectPool(200n, 1000n, [100n, 150n]);
-      expect(result).to.equal(0); // Pool 1 has a smaller balance
+      expect(result).to.equal(1); // Pool 2 has a higher balance
   })
 
   it('should balance the pools if both have reached minStake but are below maxStake', () => {

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -1,0 +1,29 @@
+import { TonPoolStaker } from '@chorus-one/ton'
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+describe('TonPoolStaker', () => {
+  it('should prioritize the pool that has not reached minStake', () => {
+      const result = TonPoolStaker.selectPool(200n, 1000n, [100n, 300n]);
+      expect(result).to.equal(0); // Pool 1 needs to reach minStake
+  })
+
+  it('should prioritize the pool with a smaller balance if both are below minStake', () => {
+      const result = TonPoolStaker.selectPool(200n, 1000n, [100n, 150n]);
+      expect(result).to.equal(0); // Pool 1 has a smaller balance
+  })
+
+  it('should balance the pools if both have reached minStake but are below maxStake', () => {
+      const result = TonPoolStaker.selectPool(200n, 1000n, [400n, 300n]);
+      expect(result).to.equal(1); // Pool 2 has a smaller balance
+  })
+
+  it('should add to the pool that has not reached maxStake', () => {
+      const result = TonPoolStaker.selectPool(200n, 1000n, [1000n, 800n]);
+      expect(result).to.equal(1); // Pool 2 has not reached maxStake
+  })
+
+  it('should throw an error if both pools have reached maxStake', () => {
+      expect(() => TonPoolStaker.selectPool(200n, 1000n, [1000n, 1000n])).to.throw("Both pools have reached their maximum stake limits.");
+  })
+})


### PR DESCRIPTION
# TL;DR
Ton Pool has two pools. We want to naively balance the pools so that ideally two pools are always in set.

This PR implements the naive balancing, by taking into account:
1. `minStake` - the amount of stake required for a pool to be in the set (taken from the lowest validator stake in past election)
2. `maxStake` - the maximum amount of stake allowed per pool (taken from chain config)
3. `poolBalance` - the current amount of available stake on the pool contract

The logic (to which u can see unittests) is simple, at first it'll try to fill up at least one if both are below minimum stake, and if both are above min, it'll fill the one with lower stake. 

If both are above maximum it will throw error. @welldan97 - Is that okay? or shall we allow people to stake above max?

## Test plan
```
$ npm run staking-cli -- ton tx delegate-pool 2 -c ./config.ton.json -s local -b
https://testnet.tonviewer.com/transaction/94cdd8e783589bb0e96083eb6c480ebded50021d88afde782c9eec5fdafc759f

$ npm run staking-cli -- ton tx unstake-pool 1.8 -c ./config.ton.json -s local -b -I 2
https://testnet.tonviewer.com/transaction/8eac38f46aef4be8a1e88b3202de010b33018c0f3a57294be84657bf4676d191
```