### PR TITLE
support BIP39 seeds for TON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3823,7 +3823,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
       "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
-      "peer": true,
       "dependencies": {
         "@ton/crypto-primitives": "2.1.0",
         "jssha": "3.2.0",
@@ -3834,7 +3833,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
       "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
-      "peer": true,
       "dependencies": {
         "jssha": "3.2.0"
       }
@@ -6895,7 +6893,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
       "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8529,16 +8526,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tonweb-mnemonic": {
-      "version": "1.0.1",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=15"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
@@ -9415,20 +9402,9 @@
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",
         "@chorus-one/utils": "^1.0.0",
-        "@noble/curves": "^1.4.0",
+        "@ton/crypto": "^3.3.0",
         "@ton/ton": "^15.1.0",
-        "axios": "^1.7.2",
-        "tonweb-mnemonic": "^1.0.1"
-      }
-    },
-    "packages/ton/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "axios": "^1.7.2"
       }
     },
     "packages/ton/node_modules/axios": {

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -92,8 +92,12 @@ async function init (
     addressDerivationFn: TonNominatorPoolStaker.getAddressDerivationFn({
       addressDerivationConfig: networkConfig.addressDerivationConfig
     }),
-    mnemonicToSeedFn: TonNominatorPoolStaker.getMnemonicToSeedFn(),
-    seedToKeypairFn: TonNominatorPoolStaker.getSeedToKeypairFn(),
+    mnemonicToSeedFn: TonNominatorPoolStaker.getMnemonicToSeedFn({
+      addressDerivationConfig: networkConfig.addressDerivationConfig
+    }),
+    seedToKeypairFn: TonNominatorPoolStaker.getSeedToKeypairFn({
+      addressDerivationConfig: networkConfig.addressDerivationConfig
+    }),
     keyType: KeyType.ED25519,
     logger: defaultLogger
   })

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -34,9 +34,8 @@
   "dependencies": {
     "@chorus-one/signer": "^1.0.0",
     "@chorus-one/utils": "^1.0.0",
-    "@noble/curves": "^1.4.0",
+    "@ton/crypto": "^3.3.0",
     "@ton/ton": "^15.1.0",
-    "axios": "^1.7.2",
-    "tonweb-mnemonic": "^1.0.1"
+    "axios": "^1.7.2"
   }
 }

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -86,6 +86,7 @@ export interface AddressDerivationConfig {
   bounceable: boolean
   testOnly: boolean
   urlSafe: boolean
+  isBIP39: boolean
 }
 
 export interface Message {


### PR DESCRIPTION
# TL;DR
BIP39 seeds are used by ledger devices and hierarchical wallets. This change is backwards compatible since previously the hdpath had to be empty.

# Test plan
run staking operation on main branch:
```
$ npm run staking-cli -- ton tx delegate-pool 0.1 -c ./config.tonpool.testnet.json -s local -b
https://testnet.tonviewer.com/transaction/6e8898baff49de738b37c3f03f2fc783eefe31b2af2df59a441918449b6f8002
```

run staking operation on `ton_support_bip39_keys` branch:
```
$ npm run staking-cli -- ton tx delegate-pool 0.1 -c ./config.tonpool.testnet.json -s local -b
https://testnet.tonviewer.com/transaction/c54c1da73eafb64597abfe4649a48bde5ab191a50f778246d8ed293ae0353d41
```

Config:
```
{
  "delegatorAddress": "0QBDG13T98PFkLCpnXzkSPlrDp39aUUhQXTqFaad5cJU4uaz",
  "validatorAddress": "kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F",
  "validatorAddress2": "kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o",

  "localsigner": {
    "mnemonicPath": "../../mnemonic",
    "accounts": [
      {
        "hdPath": ""
      }
    ]
  },

  "ledger": {
    "bounceable": false,
    "accounts": [
      {
        "hdPath": "m/44'/607'/1'/0'/0'/0'"
      }
    ]
  },

  "networkType": "ton",

  "ton": {
    "rpcUrl": "https://testnet.toncenter.com/api/v2/jsonRPC",
    "allowSeamlessWalletDeployment": true,
    "allowTransferToInactiveAccount": false,
    "minimumExistentialBalance": "0",
    "addressDerivationConfig": {
      "walletContractVersion": 4,
      "workchain": 0,
      "bounceable": false,
      "testOnly": true,
      "urlSafe": true,
      "isBIP39": false
    },
    "blockExplorerUrl": "https://testnet.tonviewer.com"
  }
}
```

Now, flipping the `isBIP39` flag to true, changes the derived address to:
```
0QBE6UXYLSiYuwCIB1PGYKKtCzTlfaZKikzSdixlsBKmHDJ5
```

which matches the address generated by the ton go version.

And changing the hd path to:
```
m/44'/607'/1'/0'/0'/0'
```

result in the same address that we get on the ledger device, this is:
```
0QBDG13T98PFkLCpnXzkSPlrDp39aUUhQXTqFaad5cJU4uaz
```