### PR TITLE
run cleanup on staking-cli and eth

### DIFF
--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -8,7 +8,6 @@
     "hardhat:stop": "kill $(cat hardhat.pid) && rm hardhat.pid",
     "test:integration": "mocha --timeout 30000 '**/*.spec.ts'",
     "test": "npm run hardhat:start > hardhat.log & sleep 5; npm run test:integration; status=$?; npm run hardhat:stop; exit $status"
-
   },
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/packages/ethereum/src/lib/contracts/keeperAbi.ts
+++ b/packages/ethereum/src/lib/contracts/keeperAbi.ts
@@ -1,737 +1,737 @@
 export const keeperABI = [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "configIpfsHash",
-          "type": "string"
-        }
-      ],
-      "name": "ConfigUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [],
-      "name": "EIP712DomainChanged",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "caller",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "nonce",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "exitSignaturesIpfsHash",
-          "type": "string"
-        }
-      ],
-      "name": "ExitSignaturesUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "rewardsRoot",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "int256",
-          "name": "totalAssetsDelta",
-          "type": "int256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "unlockedMevDelta",
-          "type": "uint256"
-        }
-      ],
-      "name": "Harvested",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "oracle",
-          "type": "address"
-        }
-      ],
-      "name": "OracleAdded",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "oracle",
-          "type": "address"
-        }
-      ],
-      "name": "OracleRemoved",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "oracles",
-          "type": "uint256"
-        }
-      ],
-      "name": "RewardsMinOraclesUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "caller",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "rewardsRoot",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "avgRewardPerSecond",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "updateTimestamp",
-          "type": "uint64"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "nonce",
-          "type": "uint64"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "rewardsIpfsHash",
-          "type": "string"
-        }
-      ],
-      "name": "RewardsUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "exitSignaturesIpfsHash",
-          "type": "string"
-        }
-      ],
-      "name": "ValidatorsApproval",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "oracles",
-          "type": "uint256"
-        }
-      ],
-      "name": "ValidatorsMinOraclesUpdated",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "oracle",
-          "type": "address"
-        }
-      ],
-      "name": "addOracle",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "bytes32",
-              "name": "validatorsRegistryRoot",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "uint256",
-              "name": "deadline",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bytes",
-              "name": "validators",
-              "type": "bytes"
-            },
-            {
-              "internalType": "bytes",
-              "name": "signatures",
-              "type": "bytes"
-            },
-            {
-              "internalType": "string",
-              "name": "exitSignaturesIpfsHash",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct IKeeperValidators.ApprovalParams",
-          "name": "params",
-          "type": "tuple"
-        }
-      ],
-      "name": "approveValidators",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        }
-      ],
-      "name": "canHarvest",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "canUpdateRewards",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "eip712Domain",
-      "outputs": [
-        {
-          "internalType": "bytes1",
-          "name": "fields",
-          "type": "bytes1"
-        },
-        {
-          "internalType": "string",
-          "name": "name",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "version",
-          "type": "string"
-        },
-        {
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "verifyingContract",
-          "type": "address"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "salt",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "uint256[]",
-          "name": "extensions",
-          "type": "uint256[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        }
-      ],
-      "name": "exitSignaturesNonces",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "bytes32",
-              "name": "rewardsRoot",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "int160",
-              "name": "reward",
-              "type": "int160"
-            },
-            {
-              "internalType": "uint160",
-              "name": "unlockedMevReward",
-              "type": "uint160"
-            },
-            {
-              "internalType": "bytes32[]",
-              "name": "proof",
-              "type": "bytes32[]"
-            }
-          ],
-          "internalType": "struct IKeeperRewards.HarvestParams",
-          "name": "params",
-          "type": "tuple"
-        }
-      ],
-      "name": "harvest",
-      "outputs": [
-        {
-          "internalType": "int256",
-          "name": "totalAssetsDelta",
-          "type": "int256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "unlockedMevDelta",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bool",
-          "name": "harvested",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_owner",
-          "type": "address"
-        }
-      ],
-      "name": "initialize",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        }
-      ],
-      "name": "isCollateralized",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        }
-      ],
-      "name": "isHarvestRequired",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "oracle",
-          "type": "address"
-        }
-      ],
-      "name": "isOracle",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "lastRewardsTimestamp",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "prevRewardsRoot",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "oracle",
-          "type": "address"
-        }
-      ],
-      "name": "removeOracle",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        }
-      ],
-      "name": "rewards",
-      "outputs": [
-        {
-          "internalType": "int192",
-          "name": "assets",
-          "type": "int192"
-        },
-        {
-          "internalType": "uint64",
-          "name": "nonce",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "rewardsDelay",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "rewardsMinOracles",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "rewardsNonce",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "rewardsRoot",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_rewardsMinOracles",
-          "type": "uint256"
-        }
-      ],
-      "name": "setRewardsMinOracles",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_validatorsMinOracles",
-          "type": "uint256"
-        }
-      ],
-      "name": "setValidatorsMinOracles",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "totalOracles",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        }
-      ],
-      "name": "unlockedMevRewards",
-      "outputs": [
-        {
-          "internalType": "uint192",
-          "name": "assets",
-          "type": "uint192"
-        },
-        {
-          "internalType": "uint64",
-          "name": "nonce",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "configIpfsHash",
-          "type": "string"
-        }
-      ],
-      "name": "updateConfig",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "vault",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "deadline",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "exitSignaturesIpfsHash",
-          "type": "string"
-        },
-        {
-          "internalType": "bytes",
-          "name": "oraclesSignatures",
-          "type": "bytes"
-        }
-      ],
-      "name": "updateExitSignatures",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "bytes32",
-              "name": "rewardsRoot",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "uint256",
-              "name": "avgRewardPerSecond",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint64",
-              "name": "updateTimestamp",
-              "type": "uint64"
-            },
-            {
-              "internalType": "string",
-              "name": "rewardsIpfsHash",
-              "type": "string"
-            },
-            {
-              "internalType": "bytes",
-              "name": "signatures",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct IKeeperRewards.RewardsUpdateParams",
-          "name": "params",
-          "type": "tuple"
-        }
-      ],
-      "name": "updateRewards",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "validatorsMinOracles",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
-  ] as const;
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'configIpfsHash',
+        type: 'string'
+      }
+    ],
+    name: 'ConfigUpdated',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'EIP712DomainChanged',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256'
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'exitSignaturesIpfsHash',
+        type: 'string'
+      }
+    ],
+    name: 'ExitSignaturesUpdated',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'rewardsRoot',
+        type: 'bytes32'
+      },
+      {
+        indexed: false,
+        internalType: 'int256',
+        name: 'totalAssetsDelta',
+        type: 'int256'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'unlockedMevDelta',
+        type: 'uint256'
+      }
+    ],
+    name: 'Harvested',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'oracle',
+        type: 'address'
+      }
+    ],
+    name: 'OracleAdded',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'oracle',
+        type: 'address'
+      }
+    ],
+    name: 'OracleRemoved',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'oracles',
+        type: 'uint256'
+      }
+    ],
+    name: 'RewardsMinOraclesUpdated',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'rewardsRoot',
+        type: 'bytes32'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'avgRewardPerSecond',
+        type: 'uint256'
+      },
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'updateTimestamp',
+        type: 'uint64'
+      },
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'nonce',
+        type: 'uint64'
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'rewardsIpfsHash',
+        type: 'string'
+      }
+    ],
+    name: 'RewardsUpdated',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'exitSignaturesIpfsHash',
+        type: 'string'
+      }
+    ],
+    name: 'ValidatorsApproval',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'oracles',
+        type: 'uint256'
+      }
+    ],
+    name: 'ValidatorsMinOraclesUpdated',
+    type: 'event'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'oracle',
+        type: 'address'
+      }
+    ],
+    name: 'addOracle',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'validatorsRegistryRoot',
+            type: 'bytes32'
+          },
+          {
+            internalType: 'uint256',
+            name: 'deadline',
+            type: 'uint256'
+          },
+          {
+            internalType: 'bytes',
+            name: 'validators',
+            type: 'bytes'
+          },
+          {
+            internalType: 'bytes',
+            name: 'signatures',
+            type: 'bytes'
+          },
+          {
+            internalType: 'string',
+            name: 'exitSignaturesIpfsHash',
+            type: 'string'
+          }
+        ],
+        internalType: 'struct IKeeperValidators.ApprovalParams',
+        name: 'params',
+        type: 'tuple'
+      }
+    ],
+    name: 'approveValidators',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      }
+    ],
+    name: 'canHarvest',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'canUpdateRewards',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'eip712Domain',
+    outputs: [
+      {
+        internalType: 'bytes1',
+        name: 'fields',
+        type: 'bytes1'
+      },
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string'
+      },
+      {
+        internalType: 'string',
+        name: 'version',
+        type: 'string'
+      },
+      {
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256'
+      },
+      {
+        internalType: 'address',
+        name: 'verifyingContract',
+        type: 'address'
+      },
+      {
+        internalType: 'bytes32',
+        name: 'salt',
+        type: 'bytes32'
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'extensions',
+        type: 'uint256[]'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      }
+    ],
+    name: 'exitSignaturesNonces',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'rewardsRoot',
+            type: 'bytes32'
+          },
+          {
+            internalType: 'int160',
+            name: 'reward',
+            type: 'int160'
+          },
+          {
+            internalType: 'uint160',
+            name: 'unlockedMevReward',
+            type: 'uint160'
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]'
+          }
+        ],
+        internalType: 'struct IKeeperRewards.HarvestParams',
+        name: 'params',
+        type: 'tuple'
+      }
+    ],
+    name: 'harvest',
+    outputs: [
+      {
+        internalType: 'int256',
+        name: 'totalAssetsDelta',
+        type: 'int256'
+      },
+      {
+        internalType: 'uint256',
+        name: 'unlockedMevDelta',
+        type: 'uint256'
+      },
+      {
+        internalType: 'bool',
+        name: 'harvested',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_owner',
+        type: 'address'
+      }
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      }
+    ],
+    name: 'isCollateralized',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      }
+    ],
+    name: 'isHarvestRequired',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'oracle',
+        type: 'address'
+      }
+    ],
+    name: 'isOracle',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'lastRewardsTimestamp',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'prevRewardsRoot',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'oracle',
+        type: 'address'
+      }
+    ],
+    name: 'removeOracle',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      }
+    ],
+    name: 'rewards',
+    outputs: [
+      {
+        internalType: 'int192',
+        name: 'assets',
+        type: 'int192'
+      },
+      {
+        internalType: 'uint64',
+        name: 'nonce',
+        type: 'uint64'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'rewardsDelay',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'rewardsMinOracles',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'rewardsNonce',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'rewardsRoot',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_rewardsMinOracles',
+        type: 'uint256'
+      }
+    ],
+    name: 'setRewardsMinOracles',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_validatorsMinOracles',
+        type: 'uint256'
+      }
+    ],
+    name: 'setValidatorsMinOracles',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalOracles',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      }
+    ],
+    name: 'unlockedMevRewards',
+    outputs: [
+      {
+        internalType: 'uint192',
+        name: 'assets',
+        type: 'uint192'
+      },
+      {
+        internalType: 'uint64',
+        name: 'nonce',
+        type: 'uint64'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'configIpfsHash',
+        type: 'string'
+      }
+    ],
+    name: 'updateConfig',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'vault',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'deadline',
+        type: 'uint256'
+      },
+      {
+        internalType: 'string',
+        name: 'exitSignaturesIpfsHash',
+        type: 'string'
+      },
+      {
+        internalType: 'bytes',
+        name: 'oraclesSignatures',
+        type: 'bytes'
+      }
+    ],
+    name: 'updateExitSignatures',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'rewardsRoot',
+            type: 'bytes32'
+          },
+          {
+            internalType: 'uint256',
+            name: 'avgRewardPerSecond',
+            type: 'uint256'
+          },
+          {
+            internalType: 'uint64',
+            name: 'updateTimestamp',
+            type: 'uint64'
+          },
+          {
+            internalType: 'string',
+            name: 'rewardsIpfsHash',
+            type: 'string'
+          },
+          {
+            internalType: 'bytes',
+            name: 'signatures',
+            type: 'bytes'
+          }
+        ],
+        internalType: 'struct IKeeperRewards.RewardsUpdateParams',
+        name: 'params',
+        type: 'tuple'
+      }
+    ],
+    name: 'updateRewards',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'validatorsMinOracles',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+] as const

--- a/packages/ethereum/src/lib/contracts/mintCotrollerAbi.ts
+++ b/packages/ethereum/src/lib/contracts/mintCotrollerAbi.ts
@@ -1,30 +1,30 @@
 export const MintTokenControllerAbi = [
-    {
-        inputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
-        name: 'convertToShares',
-        outputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-    {
-        inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
-        name: 'convertToAssets',
-        outputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-    {
-        inputs: [],
-        name: 'avgRewardPerSecond',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-    {
-        inputs: [],
-        name: 'feePercent',
-        outputs: [{ internalType: 'uint64', name: '', type: 'uint64' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-];
+  {
+    inputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
+    name: 'convertToShares',
+    outputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'convertToAssets',
+    outputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'avgRewardPerSecond',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'feePercent',
+    outputs: [{ internalType: 'uint64', name: '', type: 'uint64' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+]

--- a/packages/ethereum/src/lib/contracts/mintTokenConfigAbi.ts
+++ b/packages/ethereum/src/lib/contracts/mintTokenConfigAbi.ts
@@ -1,16 +1,16 @@
 export const MintTokenConfigAbi = [
-    {
-        inputs: [],
-        name: 'ltvPercent',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-    {
-        inputs: [],
-        name: 'liqThresholdPercent',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-];
+  {
+    inputs: [],
+    name: 'ltvPercent',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'liqThresholdPercent',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+]

--- a/packages/ethereum/src/lib/contracts/priceOracleAbi.ts
+++ b/packages/ethereum/src/lib/contracts/priceOracleAbi.ts
@@ -1,9 +1,9 @@
 export const PriceOracleAbi = [
-    {
-        inputs: [],
-        name: 'latestAnswer',
-        outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-];
+  {
+    inputs: [],
+    name: 'latestAnswer',
+    outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+]

--- a/packages/ethereum/src/lib/contracts/vaultAbi.ts
+++ b/packages/ethereum/src/lib/contracts/vaultAbi.ts
@@ -1,1256 +1,1255 @@
 export const VaultABI = [
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "name": "CheckpointCreated",
-    "type": "event"
+    name: 'CheckpointCreated',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "referrer",
-        "type": "address"
+        indexed: false,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address'
       }
     ],
-    "name": "Deposited",
-    "type": "event"
+    name: 'Deposited',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "positionTicket",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'positionTicket',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "name": "ExitQueueEntered",
-    "type": "event"
+    name: 'ExitQueueEntered',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "prevPositionTicket",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'prevPositionTicket',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "newPositionTicket",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newPositionTicket',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "withdrawnAssets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'withdrawnAssets',
+        type: 'uint256'
       }
     ],
-    "name": "ExitedAssetsClaimed",
-    "type": "event"
+    name: 'ExitedAssetsClaimed',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "feeRecipient",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'feeRecipient',
+        type: 'address'
       }
     ],
-    "name": "FeeRecipientUpdated",
-    "type": "event"
+    name: 'FeeRecipientUpdated',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: false,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "name": "FeeSharesMinted",
-    "type": "event"
+    name: 'FeeSharesMinted',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "keysManager",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'keysManager',
+        type: 'address'
       }
     ],
-    "name": "KeysManagerUpdated",
-    "type": "event"
+    name: 'KeysManagerUpdated',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "string",
-        "name": "metadataIpfsHash",
-        "type": "string"
+        indexed: false,
+        internalType: 'string',
+        name: 'metadataIpfsHash',
+        type: 'string'
       }
     ],
-    "name": "MetadataUpdated",
-    "type": "event"
+    name: 'MetadataUpdated',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "name": "OsTokenBurned",
-    "type": "event"
+    name: 'OsTokenBurned',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'user',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: false,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "osTokenShares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'osTokenShares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "receivedAssets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'receivedAssets',
+        type: 'uint256'
       }
     ],
-    "name": "OsTokenLiquidated",
-    "type": "event"
+    name: 'OsTokenLiquidated',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: false,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "referrer",
-        "type": "address"
+        indexed: false,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address'
       }
     ],
-    "name": "OsTokenMinted",
-    "type": "event"
+    name: 'OsTokenMinted',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'user',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: false,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "osTokenShares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'osTokenShares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "name": "OsTokenRedeemed",
-    "type": "event"
+    name: 'OsTokenRedeemed',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        indexed: false,
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "name": "Redeemed",
-    "type": "event"
+    name: 'Redeemed',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "publicKey",
-        "type": "bytes"
+        indexed: false,
+        internalType: 'bytes',
+        name: 'publicKey',
+        type: 'bytes'
       }
     ],
-    "name": "ValidatorRegistered",
-    "type": "event"
+    name: 'ValidatorRegistered',
+    type: 'event'
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address'
       },
       {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "validatorsRoot",
-        "type": "bytes32"
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'validatorsRoot',
+        type: 'bytes32'
       }
     ],
-    "name": "ValidatorsRootUpdated",
-    "type": "event"
+    name: 'ValidatorsRootUpdated',
+    type: 'event'
   },
   {
-    "inputs": [],
-    "name": "admin",
-    "outputs": [
+    inputs: [],
+    name: 'admin',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint128",
-        "name": "osTokenShares",
-        "type": "uint128"
+        internalType: 'uint128',
+        name: 'osTokenShares',
+        type: 'uint128'
       }
     ],
-    "name": "burnOsToken",
-    "outputs": [
+    name: 'burnOsToken',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "internalType": "uint256",
-        "name": "positionTicket",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'positionTicket',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "timestamp",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'timestamp',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "exitQueueIndex",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'exitQueueIndex',
+        type: 'uint256'
       }
     ],
-    "name": "calculateExitedAssets",
-    "outputs": [
+    name: 'calculateExitedAssets',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "leftShares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'leftShares',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "claimedShares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'claimedShares',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "claimedAssets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'claimedAssets',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "capacity",
-    "outputs": [
+    inputs: [],
+    name: 'capacity',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "positionTicket",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'positionTicket',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "timestamp",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'timestamp',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "exitQueueIndex",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'exitQueueIndex',
+        type: 'uint256'
       }
     ],
-    "name": "claimExitedAssets",
-    "outputs": [
+    name: 'claimExitedAssets',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "newPositionTicket",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'newPositionTicket',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "claimedShares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'claimedShares',
+        type: 'uint256'
       },
       {
-        "internalType": "uint256",
-        "name": "claimedAssets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'claimedAssets',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "name": "convertToAssets",
-    "outputs": [
+    name: 'convertToAssets',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "name": "convertToShares",
-    "outputs": [
+    name: 'convertToShares',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "internalType": "address",
-        "name": "referrer",
-        "type": "address"
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address'
       }
     ],
-    "name": "deposit",
-    "outputs": [
+    name: 'deposit',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "payable",
-    "type": "function"
+    stateMutability: 'payable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       }
     ],
-    "name": "enterExitQueue",
-    "outputs": [
+    name: 'enterExitQueue',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "positionTicket",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'positionTicket',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "feePercent",
-    "outputs": [
+    inputs: [],
+    name: 'feePercent',
+    outputs: [
       {
-        "internalType": "uint16",
-        "name": "",
-        "type": "uint16"
+        internalType: 'uint16',
+        name: '',
+        type: 'uint16'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "feeRecipient",
-    "outputs": [
+    inputs: [],
+    name: 'feeRecipient',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "positionTicket",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'positionTicket',
+        type: 'uint256'
       }
     ],
-    "name": "getExitQueueIndex",
-    "outputs": [
+    name: 'getExitQueueIndex',
+    outputs: [
       {
-        "internalType": "int256",
-        "name": "",
-        "type": "int256"
+        internalType: 'int256',
+        name: '',
+        type: 'int256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
+        internalType: 'address',
+        name: 'account',
+        type: 'address'
       }
     ],
-    "name": "getShares",
-    "outputs": [
+    name: 'getShares',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "implementation",
-    "outputs": [
+    inputs: [],
+    name: 'implementation',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes",
-        "name": "params",
-        "type": "bytes"
+        internalType: 'bytes',
+        name: 'params',
+        type: 'bytes'
       }
     ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "isStateUpdateRequired",
-    "outputs": [
+    inputs: [],
+    name: 'isStateUpdateRequired',
+    outputs: [
       {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "keysManager",
-    "outputs": [
+    inputs: [],
+    name: 'keysManager',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "osTokenShares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'osTokenShares',
+        type: 'uint256'
       },
       {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
       },
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       }
     ],
-    "name": "liquidateOsToken",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'liquidateOsToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "mevEscrow",
-    "outputs": [
+    inputs: [],
+    name: 'mevEscrow',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "internalType": "uint256",
-        "name": "osTokenShares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'osTokenShares',
+        type: 'uint256'
       },
       {
-        "internalType": "address",
-        "name": "referrer",
-        "type": "address"
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address'
       }
     ],
-    "name": "mintOsToken",
-    "outputs": [
+    name: 'mintOsToken',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes[]",
-        "name": "data",
-        "type": "bytes[]"
+        internalType: 'bytes[]',
+        name: 'data',
+        type: 'bytes[]'
       }
     ],
-    "name": "multicall",
-    "outputs": [
+    name: 'multicall',
+    outputs: [
       {
-        "internalType": "bytes[]",
-        "name": "results",
-        "type": "bytes[]"
+        internalType: 'bytes[]',
+        name: 'results',
+        type: 'bytes[]'
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
+        internalType: 'address',
+        name: 'user',
+        type: 'address'
       }
     ],
-    "name": "osTokenPositions",
-    "outputs": [
+    name: 'osTokenPositions',
+    outputs: [
       {
-        "internalType": "uint128",
-        "name": "shares",
-        "type": "uint128"
+        internalType: 'uint128',
+        name: 'shares',
+        type: 'uint128'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "proxiableUUID",
-    "outputs": [
+    inputs: [],
+    name: 'proxiableUUID',
+    outputs: [
       {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "queuedShares",
-    "outputs": [
+    inputs: [],
+    name: 'queuedShares',
+    outputs: [
       {
-        "internalType": "uint128",
-        "name": "",
-        "type": "uint128"
+        internalType: 'uint128',
+        name: '',
+        type: 'uint128'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "receiveFromMevEscrow",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
+    inputs: [],
+    name: 'receiveFromMevEscrow',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       },
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       }
     ],
-    "name": "redeem",
-    "outputs": [
+    name: 'redeem',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "osTokenShares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'osTokenShares',
+        type: 'uint256'
       },
       {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
       },
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       }
     ],
-    "name": "redeemOsToken",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'redeemOsToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "components": [
+        components: [
           {
-            "internalType": "bytes32",
-            "name": "validatorsRegistryRoot",
-            "type": "bytes32"
+            internalType: 'bytes32',
+            name: 'validatorsRegistryRoot',
+            type: 'bytes32'
           },
           {
-            "internalType": "uint256",
-            "name": "deadline",
-            "type": "uint256"
+            internalType: 'uint256',
+            name: 'deadline',
+            type: 'uint256'
           },
           {
-            "internalType": "bytes",
-            "name": "validators",
-            "type": "bytes"
+            internalType: 'bytes',
+            name: 'validators',
+            type: 'bytes'
           },
           {
-            "internalType": "bytes",
-            "name": "signatures",
-            "type": "bytes"
+            internalType: 'bytes',
+            name: 'signatures',
+            type: 'bytes'
           },
           {
-            "internalType": "string",
-            "name": "exitSignaturesIpfsHash",
-            "type": "string"
+            internalType: 'string',
+            name: 'exitSignaturesIpfsHash',
+            type: 'string'
           }
         ],
-        "internalType": "struct IKeeperValidators.ApprovalParams",
-        "name": "keeperParams",
-        "type": "tuple"
+        internalType: 'struct IKeeperValidators.ApprovalParams',
+        name: 'keeperParams',
+        type: 'tuple'
       },
       {
-        "internalType": "bytes32[]",
-        "name": "proof",
-        "type": "bytes32[]"
+        internalType: 'bytes32[]',
+        name: 'proof',
+        type: 'bytes32[]'
       }
     ],
-    "name": "registerValidator",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'registerValidator',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "components": [
+        components: [
           {
-            "internalType": "bytes32",
-            "name": "validatorsRegistryRoot",
-            "type": "bytes32"
+            internalType: 'bytes32',
+            name: 'validatorsRegistryRoot',
+            type: 'bytes32'
           },
           {
-            "internalType": "uint256",
-            "name": "deadline",
-            "type": "uint256"
+            internalType: 'uint256',
+            name: 'deadline',
+            type: 'uint256'
           },
           {
-            "internalType": "bytes",
-            "name": "validators",
-            "type": "bytes"
+            internalType: 'bytes',
+            name: 'validators',
+            type: 'bytes'
           },
           {
-            "internalType": "bytes",
-            "name": "signatures",
-            "type": "bytes"
+            internalType: 'bytes',
+            name: 'signatures',
+            type: 'bytes'
           },
           {
-            "internalType": "string",
-            "name": "exitSignaturesIpfsHash",
-            "type": "string"
+            internalType: 'string',
+            name: 'exitSignaturesIpfsHash',
+            type: 'string'
           }
         ],
-        "internalType": "struct IKeeperValidators.ApprovalParams",
-        "name": "keeperParams",
-        "type": "tuple"
+        internalType: 'struct IKeeperValidators.ApprovalParams',
+        name: 'keeperParams',
+        type: 'tuple'
       },
       {
-        "internalType": "uint256[]",
-        "name": "indexes",
-        "type": "uint256[]"
+        internalType: 'uint256[]',
+        name: 'indexes',
+        type: 'uint256[]'
       },
       {
-        "internalType": "bool[]",
-        "name": "proofFlags",
-        "type": "bool[]"
+        internalType: 'bool[]',
+        name: 'proofFlags',
+        type: 'bool[]'
       },
       {
-        "internalType": "bytes32[]",
-        "name": "proof",
-        "type": "bytes32[]"
+        internalType: 'bytes32[]',
+        name: 'proof',
+        type: 'bytes32[]'
       }
     ],
-    "name": "registerValidators",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'registerValidators',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "_feeRecipient",
-        "type": "address"
+        internalType: 'address',
+        name: '_feeRecipient',
+        type: 'address'
       }
     ],
-    "name": "setFeeRecipient",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'setFeeRecipient',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "_keysManager",
-        "type": "address"
+        internalType: 'address',
+        name: '_keysManager',
+        type: 'address'
       }
     ],
-    "name": "setKeysManager",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'setKeysManager',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "string",
-        "name": "metadataIpfsHash",
-        "type": "string"
+        internalType: 'string',
+        name: 'metadataIpfsHash',
+        type: 'string'
       }
     ],
-    "name": "setMetadata",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'setMetadata',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_validatorsRoot",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: '_validatorsRoot',
+        type: 'bytes32'
       }
     ],
-    "name": "setValidatorsRoot",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'setValidatorsRoot',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "totalAssets",
-    "outputs": [
+    inputs: [],
+    name: 'totalAssets',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "totalShares",
-    "outputs": [
+    inputs: [],
+    name: 'totalShares',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "components": [
+        components: [
           {
-            "internalType": "bytes32",
-            "name": "rewardsRoot",
-            "type": "bytes32"
+            internalType: 'bytes32',
+            name: 'rewardsRoot',
+            type: 'bytes32'
           },
           {
-            "internalType": "int160",
-            "name": "reward",
-            "type": "int160"
+            internalType: 'int160',
+            name: 'reward',
+            type: 'int160'
           },
           {
-            "internalType": "uint160",
-            "name": "unlockedMevReward",
-            "type": "uint160"
+            internalType: 'uint160',
+            name: 'unlockedMevReward',
+            type: 'uint160'
           },
           {
-            "internalType": "bytes32[]",
-            "name": "proof",
-            "type": "bytes32[]"
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]'
           }
         ],
-        "internalType": "struct IKeeperRewards.HarvestParams",
-        "name": "harvestParams",
-        "type": "tuple"
+        internalType: 'struct IKeeperRewards.HarvestParams',
+        name: 'harvestParams',
+        type: 'tuple'
       }
     ],
-    "name": "updateState",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'updateState',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address'
       },
       {
-        "internalType": "address",
-        "name": "referrer",
-        "type": "address"
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address'
       },
       {
-        "components": [
+        components: [
           {
-            "internalType": "bytes32",
-            "name": "rewardsRoot",
-            "type": "bytes32"
+            internalType: 'bytes32',
+            name: 'rewardsRoot',
+            type: 'bytes32'
           },
           {
-            "internalType": "int160",
-            "name": "reward",
-            "type": "int160"
+            internalType: 'int160',
+            name: 'reward',
+            type: 'int160'
           },
           {
-            "internalType": "uint160",
-            "name": "unlockedMevReward",
-            "type": "uint160"
+            internalType: 'uint160',
+            name: 'unlockedMevReward',
+            type: 'uint160'
           },
           {
-            "internalType": "bytes32[]",
-            "name": "proof",
-            "type": "bytes32[]"
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]'
           }
         ],
-        "internalType": "struct IKeeperRewards.HarvestParams",
-        "name": "harvestParams",
-        "type": "tuple"
+        internalType: 'struct IKeeperRewards.HarvestParams',
+        name: 'harvestParams',
+        type: 'tuple'
       }
     ],
-    "name": "updateStateAndDeposit",
-    "outputs": [
+    name: 'updateStateAndDeposit',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'shares',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "payable",
-    "type": "function"
+    stateMutability: 'payable',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "validatorIndex",
-    "outputs": [
+    inputs: [],
+    name: 'validatorIndex',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "validatorsRoot",
-    "outputs": [
+    inputs: [],
+    name: 'validatorsRoot',
+    outputs: [
       {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "vaultId",
-    "outputs": [
+    inputs: [],
+    name: 'vaultId',
+    outputs: [
       {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32'
       }
     ],
-    "stateMutability": "pure",
-    "type": "function"
+    stateMutability: 'pure',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "version",
-    "outputs": [
+    inputs: [],
+    name: 'version',
+    outputs: [
       {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8'
       }
     ],
-    "stateMutability": "pure",
-    "type": "function"
+    stateMutability: 'pure',
+    type: 'function'
   },
   {
-    "inputs": [],
-    "name": "withdrawableAssets",
-    "outputs": [
+    inputs: [],
+    name: 'withdrawableAssets',
+    outputs: [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function'
   }
-] as const;
-  
+] as const

--- a/packages/staking-cli/README.avalanche.md
+++ b/packages/staking-cli/README.avalanche.md
@@ -105,4 +105,5 @@ https://testnet.avascan.info/blockchain/p/tx/TD2Qc6WHwnQ9fiaLBqr61KkiWUCkDKotA6G
 NOTE: In Avalanche, there is no undelegation concept. Instead, users stake tokens for a specific period, usually starting from 14 days.
 
 ## Demo
+
 [![asciicast](https://asciinema.org/a/F45uaKU8hfTt8q8RDfBeXMfXT.svg)](https://asciinema.org/a/F45uaKU8hfTt8q8RDfBeXMfXT)

--- a/packages/staking-cli/README.cosmos.md
+++ b/packages/staking-cli/README.cosmos.md
@@ -87,4 +87,5 @@ Please be sure to always check the messages included in your transaction, the am
 - Any amount specified in the fee is distributed among the validators, therefore it is important to ensure the amount is acceptable.
 
 ### Demo
+
 [![asciicast](https://asciinema.org/a/UVLxguriRY7qrbfmaMMsccnxJ.svg)](https://asciinema.org/a/UVLxguriRY7qrbfmaMMsccnxJ)

--- a/packages/staking-cli/README.ethereum.md
+++ b/packages/staking-cli/README.ethereum.md
@@ -43,4 +43,5 @@ chorus-one-staking ethereum tx burn 1 -c ./config.ethreum.json --broadcast
 Please note, the CLI is interactive. It will prompt you before signing a transaction and broadcasting it, giving you time to review its contents.
 
 ### Demo
+
 [![asciicast](https://asciinema.org/a/eMe1QeTwN2WvsQtDvHefkws72.svg)](https://asciinema.org/a/eMe1QeTwN2WvsQtDvHefkws72)

--- a/packages/staking-cli/README.near.md
+++ b/packages/staking-cli/README.near.md
@@ -31,4 +31,5 @@ chorus-one-staking near tx withdraw 1 -c ./config.near.json --broadcast
 Please note, the CLI is interactive. It will prompt you before signing a transaction and broadcasting it, giving you time to review its contents.
 
 ### Demo
+
 [![asciicast](https://asciinema.org/a/nHT85edPgKkx5CC4jtHSK5VaB.svg)](https://asciinema.org/a/nHT85edPgKkx5CC4jtHSK5VaB)

--- a/packages/staking-cli/README.polkadot.md
+++ b/packages/staking-cli/README.polkadot.md
@@ -51,4 +51,5 @@ chorus-one-staking substrate tx withdraw -c ./config.polkadot.json --broadcast
 Please note, the CLI is interactive. It will prompt you before signing a transaction and broadcasting it, giving you time to review its contents.
 
 ### Demo
+
 [![asciicast](https://asciinema.org/a/nnfeDMDjiIwQjYSCRfDJHyeff.svg)](https://asciinema.org/a/nnfeDMDjiIwQjYSCRfDJHyeff)

--- a/packages/staking-cli/README.solana.md
+++ b/packages/staking-cli/README.solana.md
@@ -43,4 +43,5 @@ chorus-one-staking solana keys get-staking-accounts -c ../../config.solana.json
 Please note, the CLI is interactive. It will prompt you before signing a transaction and broadcasting it, giving you time to review its contents.
 
 ### Demo
+
 [![asciicast](https://asciinema.org/a/A87sSIVlH22sL3WulcD0jdJIH.svg)](https://asciinema.org/a/A87sSIVlH22sL3WulcD0jdJIH)

--- a/packages/staking-cli/README.ton.md
+++ b/packages/staking-cli/README.ton.md
@@ -40,4 +40,5 @@ The nominator pool contract doesn't allow partial unstaking. It is only possible
 Please note, the CLI is interactive. It will prompt you before signing a transaction and broadcasting it, giving you time to review its contents.
 
 ### Demo
+
 [![asciicast](https://asciinema.org/a/EyCXCh6naN1MvMJH7TXjINPk7.svg)](https://asciinema.org/a/EyCXCh6naN1MvMJH7TXjINPk7)


### PR DESCRIPTION
# TL;DR
This the result of running `npm run cleanup`.

The contract changes are pretty much only indent based and coma removals
![image](https://github.com/user-attachments/assets/3ee35223-b6ea-4521-bd09-e1b88dd325c4)
