### PR TITLE
split sign method for TonBaseStaker

### DIFF
--- a/book/docs/classes/ton_src.TonNominatorPoolStaker.md
+++ b/book/docs/classes/ton_src.TonNominatorPoolStaker.md
@@ -21,6 +21,8 @@
 - [getPoolContractNominators](ton_src.TonNominatorPoolStaker.md#getpoolcontractnominators)
 - [init](ton_src.TonNominatorPoolStaker.md#init)
 - [buildDeployWalletTx](ton_src.TonNominatorPoolStaker.md#builddeploywallettx)
+- [prepareSigningData](ton_src.TonNominatorPoolStaker.md#preparesigningdata)
+- [prepareSignedTx](ton_src.TonNominatorPoolStaker.md#preparesignedtx)
 - [sign](ton_src.TonNominatorPoolStaker.md#sign)
 - [broadcast](ton_src.TonNominatorPoolStaker.md#broadcast)
 - [getTxStatus](ton_src.TonNominatorPoolStaker.md#gettxstatus)
@@ -312,6 +314,60 @@ Returns a promise that resolves to a TON wallet deployment transaction.
 ### Inherited from
 
 TonBaseStaker.buildDeployWalletTx
+
+___
+
+## prepareSigningData
+
+▸ **prepareSigningData**(`params`): `Promise`\<`TonSigningData`\>
+
+Prepares data required for signing a transaction
+
+### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Parameters for the signing data preparation |
+| `params.signerAddress` | `string` | The address of the signer |
+| `params.signerPublicKey` | `Uint8Array` | The public key of the signer |
+| `params.tx` | [`UnsignedTx`](../interfaces/ton_src.UnsignedTx.md) | The unsigned transaction to sign |
+
+### Returns
+
+`Promise`\<`TonSigningData`\>
+
+Returns a promise that resolves to the signing data
+
+### Inherited from
+
+TonBaseStaker.prepareSigningData
+
+___
+
+## prepareSignedTx
+
+▸ **prepareSignedTx**(`params`): `Promise`\<[`SignedTx`](../interfaces/ton_src.SignedTx.md)\>
+
+Prepares a signed transaction object
+
+### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Parameters for the signed transaction preparation |
+| `params.signerAddress` | `string` | The address of the signer |
+| `params.signedTxCell` | `Cell` | The signed transaction cell |
+| `params.stateInit?` | `StateInit` | (Optional) The state init for the transaction |
+
+### Returns
+
+`Promise`\<[`SignedTx`](../interfaces/ton_src.SignedTx.md)\>
+
+A promise that resolves to a signed transaction object
+
+### Inherited from
+
+TonBaseStaker.prepareSignedTx
 
 ___
 

--- a/book/docs/classes/ton_src.TonPoolStaker.md
+++ b/book/docs/classes/ton_src.TonPoolStaker.md
@@ -25,6 +25,8 @@
 - [getPastElections](ton_src.TonPoolStaker.md#getpastelections)
 - [init](ton_src.TonPoolStaker.md#init)
 - [buildDeployWalletTx](ton_src.TonPoolStaker.md#builddeploywallettx)
+- [prepareSigningData](ton_src.TonPoolStaker.md#preparesigningdata)
+- [prepareSignedTx](ton_src.TonPoolStaker.md#preparesignedtx)
 - [sign](ton_src.TonPoolStaker.md#sign)
 - [broadcast](ton_src.TonPoolStaker.md#broadcast)
 
@@ -386,6 +388,60 @@ Returns a promise that resolves to a TON wallet deployment transaction.
 ### Inherited from
 
 TonBaseStaker.buildDeployWalletTx
+
+___
+
+## prepareSigningData
+
+▸ **prepareSigningData**(`params`): `Promise`\<`TonSigningData`\>
+
+Prepares data required for signing a transaction
+
+### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Parameters for the signing data preparation |
+| `params.signerAddress` | `string` | The address of the signer |
+| `params.signerPublicKey` | `Uint8Array` | The public key of the signer |
+| `params.tx` | [`UnsignedTx`](../interfaces/ton_src.UnsignedTx.md) | The unsigned transaction to sign |
+
+### Returns
+
+`Promise`\<`TonSigningData`\>
+
+Returns a promise that resolves to the signing data
+
+### Inherited from
+
+TonBaseStaker.prepareSigningData
+
+___
+
+## prepareSignedTx
+
+▸ **prepareSignedTx**(`params`): `Promise`\<[`SignedTx`](../interfaces/ton_src.SignedTx.md)\>
+
+Prepares a signed transaction object
+
+### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Parameters for the signed transaction preparation |
+| `params.signerAddress` | `string` | The address of the signer |
+| `params.signedTxCell` | `Cell` | The signed transaction cell |
+| `params.stateInit?` | `StateInit` | (Optional) The state init for the transaction |
+
+### Returns
+
+`Promise`\<[`SignedTx`](../interfaces/ton_src.SignedTx.md)\>
+
+A promise that resolves to a signed transaction object
+
+### Inherited from
+
+TonBaseStaker.prepareSignedTx
 
 ___
 

--- a/book/docs/classes/ton_src.TonSingleNominatorPoolStaker.md
+++ b/book/docs/classes/ton_src.TonSingleNominatorPoolStaker.md
@@ -21,6 +21,8 @@
 - [getPoolContractNominators](ton_src.TonSingleNominatorPoolStaker.md#getpoolcontractnominators)
 - [init](ton_src.TonSingleNominatorPoolStaker.md#init)
 - [buildDeployWalletTx](ton_src.TonSingleNominatorPoolStaker.md#builddeploywallettx)
+- [prepareSigningData](ton_src.TonSingleNominatorPoolStaker.md#preparesigningdata)
+- [prepareSignedTx](ton_src.TonSingleNominatorPoolStaker.md#preparesignedtx)
 - [sign](ton_src.TonSingleNominatorPoolStaker.md#sign)
 - [broadcast](ton_src.TonSingleNominatorPoolStaker.md#broadcast)
 - [getTxStatus](ton_src.TonSingleNominatorPoolStaker.md#gettxstatus)
@@ -313,6 +315,60 @@ Returns a promise that resolves to a TON wallet deployment transaction.
 ### Inherited from
 
 TonBaseStaker.buildDeployWalletTx
+
+___
+
+## prepareSigningData
+
+▸ **prepareSigningData**(`params`): `Promise`\<`TonSigningData`\>
+
+Prepares data required for signing a transaction
+
+### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Parameters for the signing data preparation |
+| `params.signerAddress` | `string` | The address of the signer |
+| `params.signerPublicKey` | `Uint8Array` | The public key of the signer |
+| `params.tx` | [`UnsignedTx`](../interfaces/ton_src.UnsignedTx.md) | The unsigned transaction to sign |
+
+### Returns
+
+`Promise`\<`TonSigningData`\>
+
+Returns a promise that resolves to the signing data
+
+### Inherited from
+
+TonBaseStaker.prepareSigningData
+
+___
+
+## prepareSignedTx
+
+▸ **prepareSignedTx**(`params`): `Promise`\<[`SignedTx`](../interfaces/ton_src.SignedTx.md)\>
+
+Prepares a signed transaction object
+
+### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Parameters for the signed transaction preparation |
+| `params.signerAddress` | `string` | The address of the signer |
+| `params.signedTxCell` | `Cell` | The signed transaction cell |
+| `params.stateInit?` | `StateInit` | (Optional) The state init for the transaction |
+
+### Returns
+
+`Promise`\<[`SignedTx`](../interfaces/ton_src.SignedTx.md)\>
+
+A promise that resolves to a signed transaction object
+
+### Inherited from
+
+TonBaseStaker.prepareSignedTx
 
 ___
 

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -14,6 +14,7 @@ export interface TonSigningData {
     sendMode: number
     walletId: number
     messages: MessageRelaxed[]
+    stateInit?: StateInit
     timeout?: number
   }
 }


### PR DESCRIPTION
# TL;DR
The `sign` method does a few other things (like wallet creation etc) prior calling the `signer`. If SDK user wants to skip the signer, he/she would have to replicate some of the logic which ain't great.

This PR splits the `sign` method into:
1. `prepareSigningData` - prepare the final transaction
2. `prepareSignerTx` - turns signed TxCell into a SignedTx structure

Example without signer abstraction:
```typescript
const staker = TonPoolStaker(...)
const externalCustomSigner = signer({ ... })
const { signerAddress, signerPublicKey } = signer({...})

const signingData = await this.prepareSigningData({
  signerAddress,
  signerPublicKey,
  tx: await staker.buildStakeTx(...)
})

// sign transaction via custom signer or call some method that returns the signedTx Cell
const signedTxCell = await externalCustomSigner.sign(signingData.txCell)

const signedTx = await this.prepareSignedTx({
  signerAddress,
  signedTxCell,
  stateInit: signingData.txArgs.stateInit
})

staker.broadcast({ signedTx })

```