### PR TITLE
ton pool: stake to both pools at once

### DIFF
--- a/packages/staking-cli/package.json
+++ b/packages/staking-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/staking-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "All in one CLI for running staking operations on many blockchain networks",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.cjs.json --outDir dist/cjs && chmod +x dist/cjs/index.js",
@@ -36,7 +36,7 @@
     "@chorus-one/signer-local": "^1.0.0",
     "@chorus-one/solana": "^1.0.0",
     "@chorus-one/substrate": "^1.0.1",
-    "@chorus-one/ton": "^2.1.0",
+    "@chorus-one/ton": "^2.2.0",
     "@chorus-one/utils": "^1.0.1",
     "@commander-js/extra-typings": "^11.1.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.5",

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -150,16 +150,12 @@ async function runTx (
           cmd.error('second validator address is required for TON Pool', { exitCode: 1, code: `${msgType}.tx.abort` })
         }
         const stakingPoolAddressPair: [string, string] = [config.validatorAddress, config.validatorAddress2]
-        const poolsInfo = await tonStaker.getPoolAddressForStake({ validatorAddressPair: stakingPoolAddressPair })
-        const poolIndex = stakingPoolAddressPair.findIndex((addr: string) => addr === poolsInfo.selectedPoolAddress)
-        if (poolIndex === -1) {
-          cmd.error('validator address not found in the pool', { exitCode: 1, code: `${msgType}.tx.abort` })
-        }
 
-        console.log('Delegating to pool #' + (poolIndex + 1) + ': ' + stakingPoolAddressPair[poolIndex])
+        console.log('Delegating to pool(s): ' + stakingPoolAddressPair.filter((addr) => addr !== "").join(', '))
 
         unsignedTx = (
           await tonStaker.buildStakeTx({
+            delegatorAddress: config.delegatorAddress,
             validatorAddressPair: stakingPoolAddressPair,
             amount: arg[0] // amount
           })

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -8,6 +8,7 @@ import { prompt, readConfig, getNetworkConfig, log, defaultLogger } from '../uti
 import { SafeJSONStringify } from '@chorus-one/utils'
 import { newSigner } from '../signer'
 import { TonPoolStaker, TonNominatorPoolStaker, TonSingleNominatorPoolStaker } from '@chorus-one/ton'
+import { fromNano } from '@ton/ton'
 
 export interface CLINetworkConfig extends TonNetworkConfig {
   // block explorer URL to display Transaction ID via Web UI. Example:
@@ -160,6 +161,15 @@ async function runTx (
             amount: arg[0] // amount
           })
         ).tx
+
+        if (unsignedTx.messages === undefined) {
+          throw new Error('no messages found in the unsigned transaction')
+        }
+
+        console.log('Staking to the following contracts:')
+        unsignedTx.messages.forEach((msg) => {
+          console.log(`* ${msg.address} with ${fromNano(msg.amount)} TON`)
+        })
         break
       }
       case 'unstake-pool': {

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -145,7 +145,7 @@ async function runTx (
   try {
     switch (msgType) {
       case 'delegate-pool': {
-        const preferredStrategy: string = cmd.getOptionValue('strategy') as 'balanced' | 'split' | 'single'
+        const preferredStrategy = cmd.getOptionValue('strategy') as 'balanced' | 'split' | 'single'
         tonStaker = new TonPoolStaker({
           ...networkConfig,
         })

--- a/packages/staking-cli/src/cmd/ton.ts
+++ b/packages/staking-cli/src/cmd/ton.ts
@@ -168,7 +168,7 @@ async function runTx (
 
         console.log('Staking to the following contracts:')
         unsignedTx.messages.forEach((msg) => {
-          console.log(`* ${msg.address} with ${fromNano(msg.amount)} TON`)
+          console.log(`* ${msg.address} with ${fromNano(msg.amount)} TON (${msg.amount} nanoTON)`)
         })
         break
       }

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/ton",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "All-in-one tooling for building staking dApps on TON",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json"

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -97,7 +97,7 @@ export class TonPoolStaker extends TonBaseStaker {
 
       // sanity check
       if (stakeAmountPerPool.reduce((acc, val) => acc + val, 0n) !== toNano(amount)) {
-        throw new Error('unstake amount does not match the requested amount')
+        throw new Error('stake amount does not match the requested amount')
       }
 
       validatorAddresses.forEach((validatorAddress, index) => {
@@ -487,27 +487,27 @@ export class TonPoolStaker extends TonBaseStaker {
     currentPoolBalances: [bigint, bigint], // current stake balances of the pools
     currentUserStakes: [bigint, bigint] // current user stakes in the pools
   ): [bigint, bigint] {
-    const [pool1Balance, pool2Balance] = currentPoolBalances
-    const [user1Stake, user2Stake] = currentUserStakes
+    const [poolOneBalance, poolTwoBalance] = currentPoolBalances
+    const [userOneStake, userTwoStake] = currentUserStakes
 
-    const totalUserStake = user1Stake + user2Stake + amount
+    const totalUserStake = userOneStake + userTwoStake + amount
     const idealUserSplit = totalUserStake / 2n
     const result: [bigint, bigint] = [0n, 0n]
 
     // case: both pools are at or above minStake
-    const pool1AboveMin = pool1Balance >= minStake
-    const pool2AboveMin = pool2Balance >= minStake
+    const poolOneAboveMin = poolOneBalance >= minStake
+    const poolTwoAboveMin = poolTwoBalance >= minStake
 
-    if (pool1AboveMin && pool2AboveMin) {
+    if (poolOneAboveMin && poolTwoAboveMin) {
       // aim for user balance
-      result[0] = idealUserSplit - user1Stake
-      result[1] = idealUserSplit - user2Stake
+      result[0] = idealUserSplit - userOneStake
+      result[1] = amount - result[0]
       return result
     }
 
     // case: one pool is below minStake and one is above
-    if (pool1Balance < minStake && pool2Balance >= minStake) {
-      const needed = minStake - pool1Balance
+    if (poolOneBalance < minStake && poolTwoBalance >= minStake) {
+      const needed = minStake - poolOneBalance
       if (amount >= needed) {
         result[0] = needed
         const remaining = amount - needed
@@ -517,8 +517,8 @@ export class TonPoolStaker extends TonBaseStaker {
       }
     }
 
-    if (pool2Balance < minStake && pool1Balance >= minStake) {
-      const needed = minStake - pool2Balance
+    if (poolTwoBalance < minStake && poolOneBalance >= minStake) {
+      const needed = minStake - poolTwoBalance
       if (amount >= needed) {
         result[1] = needed
         const remaining = amount - needed
@@ -529,8 +529,8 @@ export class TonPoolStaker extends TonBaseStaker {
     }
 
     // case: both pools are below minStake
-    if (!pool1AboveMin && !pool2AboveMin) {
-      const needed1 = minStake - pool1Balance
+    if (!poolOneAboveMin && !poolTwoAboveMin) {
+      const needed1 = minStake - poolOneBalance
       if (amount <= needed1) {
         result[0] = amount
         return result

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -133,7 +133,6 @@ export class TonPoolStaker extends TonBaseStaker {
           minElectionStake,
           currentPoolBalances,
           currentUserStakes,
-          [poolParams[0].minStakeTotal, poolParams[1].minStakeTotal]
         )
 
         validatorAddresses.forEach((validatorAddress, index) => {
@@ -576,11 +575,9 @@ export class TonPoolStaker extends TonBaseStaker {
     amount: bigint, // amount to stake
     minStake: bigint, // minimum stake for participation (to be in the set)
     currentPoolBalances: [bigint, bigint], // current stake balances of the pools
-    currentUserStakes: [bigint, bigint], // current user stakes in the pools
     minPoolStakes: [bigint, bigint] // min staked amount per pool
   ): [bigint, bigint] {
     const [poolOneBalance, poolTwoBalance] = currentPoolBalances
-    const [userOneStake, userTwoStake] = currentUserStakes
     const [minPoolOne, minPoolTwo] = minPoolStakes
 
     if (amount < minPoolOne || amount < minPoolTwo) {
@@ -595,12 +592,11 @@ export class TonPoolStaker extends TonBaseStaker {
       const poolTwoAboveMin = poolTwoBalance >= minStake
 
       // here we know that both pools will get elected therefore
-      // we should balance the user stakes (instead of pool stakes) to maximize
-      // the rewards
+      // we should balance the user stake to equalize the pool balances
       if (poolOneAboveMin && poolTwoAboveMin) {
-        const highestStakeI = userOneStake > userTwoStake ? 0 : 1
+        const highestStakeI = poolOneBalance > poolTwoBalance ? 0 : 1
         const lowerStakeI = highestStakeI === 1 ? 0 : 1
-        const stakedDelta = currentUserStakes[highestStakeI] - currentUserStakes[lowerStakeI]
+        const stakedDelta = currentPoolBalances[highestStakeI] - currentPoolBalances[lowerStakeI]
 
         const remainder = amount - stakedDelta
 

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -11,14 +11,7 @@ import {
   TransactionDescriptionGeneric
 } from '@ton/ton'
 import { defaultValidUntil, getDefaultGas, getRandomQueryId, TonBaseStaker } from './TonBaseStaker'
-import {
-  UnsignedTx,
-  Election,
-  FrozenSet,
-  PoolStatus,
-  Message,
-  TonTxStatus
-} from './types'
+import { UnsignedTx, Election, FrozenSet, PoolStatus, Message, TonTxStatus } from './types'
 
 export class TonPoolStaker extends TonBaseStaker {
   /**
@@ -37,7 +30,7 @@ export class TonPoolStaker extends TonBaseStaker {
    * @returns Returns a promise that resolves to a TON nominator pool staking transaction.
    */
   async buildStakeTx (params: {
-    delegatorAddress: string,
+    delegatorAddress: string
     validatorAddressPair: [string, string]
     amount: string
     referrer?: string
@@ -65,10 +58,7 @@ export class TonPoolStaker extends TonBaseStaker {
       }
     })
 
-    const genStakeMsg = (
-      validatorAddress: string,
-      amount: bigint,
-    ): Message => {
+    const genStakeMsg = (validatorAddress: string, amount: bigint): Message => {
       // https://github.com/tonwhales/ton-nominators/blob/0553e1b6ddfc5c0b60505957505ce58d01bec3e7/compiled/nominators.fc#L18
       let basePayload = beginCell()
         .storeUint(2077040623, 32) // stake_deposit method const
@@ -117,7 +107,7 @@ export class TonPoolStaker extends TonBaseStaker {
         msgs.push(genStakeMsg(validatorAddress, stakeAmountPerPool[index]))
       })
     } else {
-      const validatorAddress = validatorAddresses[0] !== "" ? validatorAddresses[0] : validatorAddresses[1]
+      const validatorAddress = validatorAddresses[0] !== '' ? validatorAddresses[0] : validatorAddresses[1]
       msgs.push(genStakeMsg(validatorAddress, toNano(amount)))
     }
 
@@ -337,15 +327,10 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  private async getPoolDataForDelegator (
-    delegatorAddress: string,
-    validatorAddresses: string[],
-  ) {
+  private async getPoolDataForDelegator (delegatorAddress: string, validatorAddresses: string[]) {
     const [poolStatus, userStake, minStake] = await Promise.all([
       Promise.all(validatorAddresses.map((validatorAddress) => this.getPoolStatus(validatorAddress))),
-      Promise.all(
-        validatorAddresses.map((validatorAddress) => this.getStake({ delegatorAddress, validatorAddress }))
-      ),
+      Promise.all(validatorAddresses.map((validatorAddress) => this.getStake({ delegatorAddress, validatorAddress }))),
       this.getMinStake()
     ])
 
@@ -502,63 +487,63 @@ export class TonPoolStaker extends TonBaseStaker {
     currentPoolBalances: [bigint, bigint], // current stake balances of the pools
     currentUserStakes: [bigint, bigint] // current user stakes in the pools
   ): [bigint, bigint] {
-    const [pool1Balance, pool2Balance] = currentPoolBalances;
-    const [user1Stake, user2Stake] = currentUserStakes;
+    const [pool1Balance, pool2Balance] = currentPoolBalances
+    const [user1Stake, user2Stake] = currentUserStakes
 
-    const totalUserStake = user1Stake + user2Stake + amount;
-    const idealUserSplit = totalUserStake / 2n;
-    const result: [bigint, bigint] = [0n, 0n];
+    const totalUserStake = user1Stake + user2Stake + amount
+    const idealUserSplit = totalUserStake / 2n
+    const result: [bigint, bigint] = [0n, 0n]
 
     // case: both pools are at or above minStake
-    const pool1AboveMin = pool1Balance >= minStake;
-    const pool2AboveMin = pool2Balance >= minStake;
+    const pool1AboveMin = pool1Balance >= minStake
+    const pool2AboveMin = pool2Balance >= minStake
 
     if (pool1AboveMin && pool2AboveMin) {
       // aim for user balance
-      result[0] = idealUserSplit - user1Stake;
-      result[1] = idealUserSplit - user2Stake;
-      return result;
+      result[0] = idealUserSplit - user1Stake
+      result[1] = idealUserSplit - user2Stake
+      return result
     }
 
     // case: one pool is below minStake and one is above
     if (pool1Balance < minStake && pool2Balance >= minStake) {
-      const needed = minStake - pool1Balance;
+      const needed = minStake - pool1Balance
       if (amount >= needed) {
-        result[0] = needed;
-        const remaining = amount - needed;
-        result[0] += remaining / 2n;
-        result[1] = remaining - (remaining / 2n);
-        return result;
+        result[0] = needed
+        const remaining = amount - needed
+        result[0] += remaining / 2n
+        result[1] = remaining - remaining / 2n
+        return result
       }
     }
 
     if (pool2Balance < minStake && pool1Balance >= minStake) {
-      const needed = minStake - pool2Balance;
+      const needed = minStake - pool2Balance
       if (amount >= needed) {
-        result[1] = needed;
-        const remaining = amount - needed;
-        result[0] = remaining / 2n;
-        result[1] += remaining - (remaining / 2n);
-        return result;
+        result[1] = needed
+        const remaining = amount - needed
+        result[0] = remaining / 2n
+        result[1] += remaining - remaining / 2n
+        return result
       }
     }
 
     // case: both pools are below minStake
     if (!pool1AboveMin && !pool2AboveMin) {
-      const needed1 = minStake - pool1Balance;
+      const needed1 = minStake - pool1Balance
       if (amount <= needed1) {
-        result[0] = amount;
-        return result;
+        result[0] = amount
+        return result
       }
 
-      result[0] = needed1;
-      result[1] = amount - needed1;
-      return result;
+      result[0] = needed1
+      result[1] = amount - needed1
+      return result
     }
 
     // fallback: split 50/50
-    result[0] = amount / 2n;
-    result[1] = amount - result[0];
-    return result;
+    result[0] = amount / 2n
+    result[1] = amount - result[0]
+    return result
   }
 }

--- a/packages/ton/src/types.d.ts
+++ b/packages/ton/src/types.d.ts
@@ -83,12 +83,6 @@ export interface PoolStatus {
   balanceWithdraw: bigint
 }
 
-export interface GetPoolAddressForStakeResponse {
-  selectedPoolAddress: string
-  minStake: bigint
-  poolStakes: [biginy, bigint]
-}
-
 export interface AddressDerivationConfig {
   walletContractVersion: number
   workchain: number

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -2,67 +2,92 @@ import { TonPoolStaker } from '@chorus-one/ton'
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
 
-describe('TonPoolStaker_selectPool', () => {
-  it('should prioritize the pool that has not reached minStake', () => {
-    const result = TonPoolStaker.selectPool(200n, [100n, 300n])
-    expect(result).to.equal(0) // Pool 1 needs to reach minStake
-  })
-
-  it('should prioritize the pool with a higher balance if both are below minStake', () => {
-    const result = TonPoolStaker.selectPool(200n, [100n, 150n])
-    expect(result).to.equal(1) // Pool 2 has a higher balance
-  })
-
-  it('should balance the pools if both have reached minStake', () => {
-    const result = TonPoolStaker.selectPool(200n, [400n, 300n])
-    expect(result).to.equal(1) // Pool 2 has a smaller balance
-  })
-})
-
 describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
+  const fn = TonPoolStaker.calculateUnstakePoolAmount;
   const minStake = 10n
 
   it('should withdraw from the highest balance pool first', () => {
-    const result = TonPoolStaker.calculateUnstakePoolAmount(5n, minStake, [15n, 20n], [10n, 10n])
+    const result = fn(5n, minStake, [15n, 20n], [10n, 10n])
     expect(result).to.deep.equal([0n, 5n])
   })
 
   it('should not split withdraw to two pools if not required', () => {
-    const result = TonPoolStaker.calculateUnstakePoolAmount(10n, minStake, [20n, 20n], [10n, 10n])
+    const result = fn(10n, minStake, [20n, 20n], [10n, 10n])
     expect(result).to.deep.equal([10n, 0n])
   })
 
   it('should split withdraw to avoid pool deactivation', () => {
-    const result = TonPoolStaker.calculateUnstakePoolAmount(10n, minStake, [15n, 15n], [10n, 10n])
+    const result = fn(10n, minStake, [15n, 15n], [10n, 10n])
     expect(result).to.deep.equal([5n, 5n])
   })
 
   it('should withdraw from multiple pools if needed', () => {
-    const result = TonPoolStaker.calculateUnstakePoolAmount(15n, minStake, [20n, 20n], [10n, 10n])
+    const result = fn(15n, minStake, [20n, 20n], [10n, 10n])
     expect(result).to.deep.equal([10n, 5n])
   })
 
   it('should not withdraw if user stake is zero', () => {
-    const result = TonPoolStaker.calculateUnstakePoolAmount(5n, minStake, [15n, 20n], [0n, 10n])
+    const result = fn(5n, minStake, [15n, 20n], [0n, 10n])
     expect(result).to.deep.equal([0n, 5n])
   })
 
   it('should handle exact balance matches', () => {
-    const result = TonPoolStaker.calculateUnstakePoolAmount(10n, minStake, [20n, 20n], [10n, 5n])
+    const result = fn(10n, minStake, [20n, 20n], [10n, 5n])
     expect(result).to.deep.equal([10n, 0n])
   })
 
   it('should withdraw if one pool is empty', () => {
-    let result = TonPoolStaker.calculateUnstakePoolAmount(5n, minStake, [0n, 20n], [0n, 5n])
+    let result = fn(5n, minStake, [0n, 20n], [0n, 5n])
     expect(result).to.deep.equal([0n, 5n])
 
-    result = TonPoolStaker.calculateUnstakePoolAmount(5n, minStake, [20n, 10n], [5n, 0n])
+    result = fn(5n, minStake, [20n, 10n], [5n, 0n])
     expect(result).to.deep.equal([5n, 0n])
   })
 
   it('should throw error if user wants to withdraw more than available', () => {
-    expect(() => TonPoolStaker.calculateUnstakePoolAmount(21n, 10n, [20n, 20n], [10n, 10n])).to.throw(
+    expect(() => fn(21n, 10n, [20n, 20n], [10n, 10n])).to.throw(
       'requested withdrawal amount exceeds available user stakes'
     )
   })
+});
+
+describe('TonPoolStaker_calculateStakeAmount', () => {
+    const fn = TonPoolStaker.calculateStakePoolAmount;
+
+    it('should split equally when both pools are above minStake and user stake is balanced', () => {
+      const result = fn(1000n, 500n, [1000n, 1000n], [500n, 500n]);
+      expect(result).to.eql([500n, 500n]);
+    });
+
+    it('should top up pool1 to minStake and split remainder', () => {
+      const result = fn(1000n, 1000n, [500n, 1500n], [0n, 0n]);
+      // 500 to pool1, remaining 500 split -> 250 to each
+      expect(result).to.eql([750n, 250n]);
+    });
+
+    it('should top up pool2 to minStake and split remainder', () => {
+      const result = fn(1000n, 1000n, [1500n, 500n], [0n, 0n]);
+      expect(result).to.eql([250n, 750n]);
+    });
+
+    it('should fill pool1 to minStake and send rest to pool2 if both below minStake', () => {
+      const result = fn(1500n, 1000n, [400n, 400n], [0n, 0n]);
+      // 600 to pool1 to hit minStake, 900 to pool2
+      expect(result).to.eql([600n, 900n]);
+    });
+
+    it('should assign all to pool1 if both pools below minStake and amount is too small', () => {
+      const result = fn(300n, 1000n, [500n, 500n], [0n, 0n]);
+      expect(result).to.eql([300n, 0n]);
+    });
+
+    it('should fallback to even split when unsure (e.g., both pools at min and no user balance)', () => {
+      const result = fn(1000n, 1000n, [1000n, 1000n], [0n, 0n]);
+      expect(result).to.eql([500n, 500n]);
+    });
+
+    it('should balance based on the user stake when both pools are above minStake', () => {
+      const result = fn(500n, 1000n, [1000n, 1000n], [200n, 300n]);
+      expect(result).to.eql([300n, 200n]);
+    });
 })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -3,6 +3,23 @@ import { TonPoolStaker } from '@chorus-one/ton'
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
 
+describe('TonPoolStaker_selectPool', () => {
+  it('should prioritize the pool that has not reached minStake', () => {
+    const result = TonPoolStaker.selectPool(200n, [100n, 300n])
+    expect(result).to.equal(0) // Pool 1 needs to reach minStake
+  })
+
+  it('should prioritize the pool with a higher balance if both are below minStake', () => {
+    const result = TonPoolStaker.selectPool(200n, [100n, 150n])
+    expect(result).to.equal(1) // Pool 2 has a higher balance
+  })
+
+  it('should balance the pools if both have reached minStake', () => {
+    const result = TonPoolStaker.selectPool(200n, [400n, 300n])
+    expect(result).to.equal(1) // Pool 2 has a smaller balance
+  })
+})
+
 describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const fn = TonPoolStaker.calculateUnstakePoolAmount
   const minStake = 10n

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -1,3 +1,4 @@
+import { toNano } from '@ton/ton'
 import { TonPoolStaker } from '@chorus-one/ton'
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
@@ -89,5 +90,15 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
   it('should balance based on the user stake when both pools are above minStake', () => {
     const result = fn(500n, 1000n, [1000n, 1000n], [200n, 300n])
     expect(result).to.eql([300n, 200n])
+  })
+
+  it('should handle uneven stake amounts', () => {
+    // even pool stakes
+    const result_one = fn(toNano(503), toNano(500), [toNano(1000), toNano(1000)], [toNano(500), toNano(500)])
+    expect(result_one).to.eql([toNano(251.5), toNano(251.5)])
+
+    // uneven pool stakes
+    const result_two = fn(503n, 500n, [1000n, 1000n], [500n, 500n])
+    expect(result_two).to.eql([251n, 252n])
   })
 })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha'
 import { expect } from 'chai'
 
 describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
-  const fn = TonPoolStaker.calculateUnstakePoolAmount;
+  const fn = TonPoolStaker.calculateUnstakePoolAmount
   const minStake = 10n
 
   it('should withdraw from the highest balance pool first', () => {
@@ -49,45 +49,45 @@ describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
       'requested withdrawal amount exceeds available user stakes'
     )
   })
-});
+})
 
 describe('TonPoolStaker_calculateStakeAmount', () => {
-    const fn = TonPoolStaker.calculateStakePoolAmount;
+  const fn = TonPoolStaker.calculateStakePoolAmount
 
-    it('should split equally when both pools are above minStake and user stake is balanced', () => {
-      const result = fn(1000n, 500n, [1000n, 1000n], [500n, 500n]);
-      expect(result).to.eql([500n, 500n]);
-    });
+  it('should split equally when both pools are above minStake and user stake is balanced', () => {
+    const result = fn(1000n, 500n, [1000n, 1000n], [500n, 500n])
+    expect(result).to.eql([500n, 500n])
+  })
 
-    it('should top up pool1 to minStake and split remainder', () => {
-      const result = fn(1000n, 1000n, [500n, 1500n], [0n, 0n]);
-      // 500 to pool1, remaining 500 split -> 250 to each
-      expect(result).to.eql([750n, 250n]);
-    });
+  it('should top up pool1 to minStake and split remainder', () => {
+    const result = fn(1000n, 1000n, [500n, 1500n], [0n, 0n])
+    // 500 to pool1, remaining 500 split -> 250 to each
+    expect(result).to.eql([750n, 250n])
+  })
 
-    it('should top up pool2 to minStake and split remainder', () => {
-      const result = fn(1000n, 1000n, [1500n, 500n], [0n, 0n]);
-      expect(result).to.eql([250n, 750n]);
-    });
+  it('should top up pool2 to minStake and split remainder', () => {
+    const result = fn(1000n, 1000n, [1500n, 500n], [0n, 0n])
+    expect(result).to.eql([250n, 750n])
+  })
 
-    it('should fill pool1 to minStake and send rest to pool2 if both below minStake', () => {
-      const result = fn(1500n, 1000n, [400n, 400n], [0n, 0n]);
-      // 600 to pool1 to hit minStake, 900 to pool2
-      expect(result).to.eql([600n, 900n]);
-    });
+  it('should fill pool1 to minStake and send rest to pool2 if both below minStake', () => {
+    const result = fn(1500n, 1000n, [400n, 400n], [0n, 0n])
+    // 600 to pool1 to hit minStake, 900 to pool2
+    expect(result).to.eql([600n, 900n])
+  })
 
-    it('should assign all to pool1 if both pools below minStake and amount is too small', () => {
-      const result = fn(300n, 1000n, [500n, 500n], [0n, 0n]);
-      expect(result).to.eql([300n, 0n]);
-    });
+  it('should assign all to pool1 if both pools below minStake and amount is too small', () => {
+    const result = fn(300n, 1000n, [500n, 500n], [0n, 0n])
+    expect(result).to.eql([300n, 0n])
+  })
 
-    it('should fallback to even split when unsure (e.g., both pools at min and no user balance)', () => {
-      const result = fn(1000n, 1000n, [1000n, 1000n], [0n, 0n]);
-      expect(result).to.eql([500n, 500n]);
-    });
+  it('should fallback to even split when unsure (e.g., both pools at min and no user balance)', () => {
+    const result = fn(1000n, 1000n, [1000n, 1000n], [0n, 0n])
+    expect(result).to.eql([500n, 500n])
+  })
 
-    it('should balance based on the user stake when both pools are above minStake', () => {
-      const result = fn(500n, 1000n, [1000n, 1000n], [200n, 300n]);
-      expect(result).to.eql([300n, 200n]);
-    });
+  it('should balance based on the user stake when both pools are above minStake', () => {
+    const result = fn(500n, 1000n, [1000n, 1000n], [200n, 300n])
+    expect(result).to.eql([300n, 200n])
+  })
 })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -74,19 +74,17 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
   const minPoolStakes = [1n, 1n]
 
   it('should equalize the user stake if both pools are above min', () => {
-    // equalize the user stake across both pools
     // strategy: both pools are above minStake, so our goal is to optimize the
-    // balance for the user stake (not for pool stake)
-    const result = fn(1000n, 500n, [1000n, 1000n], [250n, 200n], minPoolStakes)
+    // balance for the pool stake
+    const result = fn(1000n, 200n, [250n, 200n], minPoolStakes)
     expect(result).to.eql([475n, 525n])
 
-    // if user balances are equal, split the stake evenly
+    // if pool balances are equal, split the stake evenly
     // the lower balance
     const result_tw = fn(
       toNano(5), // to stake
       toNano(5), // minmum for election
       [toNano(10), toNano(10)], // current pool balances
-      [toNano(10), toNano(10)], // current user stakes
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_tw).to.eql([toNano(2.5), toNano(2.5)])
@@ -97,7 +95,6 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
       toNano(3), // to stake
       toNano(5), // minmum for election
       [toNano(5), toNano(10)], // current pool balances
-      [toNano(5), toNano(10)], // current user stakes
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_two).to.eql([toNano(3), toNano(0)])
@@ -107,7 +104,6 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
       toNano(5), // to stake
       toNano(5), // minmum for election
       [toNano(5), toNano(10)], // current pool balances
-      [toNano(5), toNano(10)], // current user stakes
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_three).to.eql([toNano(5), toNano(0)])
@@ -119,19 +115,17 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
       toNano(6), // to stake
       toNano(5), // minmum for election
       [toNano(5), toNano(10)], // current pool balances
-      [toNano(5), toNano(10)], // current user stakes
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_four).to.eql([toNano(5), toNano(1)])
 
     // it's not possible to blance the stakes and keep the minimum stake
-    // so resign from blancing the current user stake and simply split the
+    // so resign from blancing the pool stake and simply split the
     // amount between the pools
     const result_five = fn(
       toNano(2.4), // to stake
-      toNano(58418.512270274), // minmum for election
-      [toNano(138935.813773278), toNano(137495.974875379)],
-      [toNano(1.871), toNano(1.7348)], // current user stakes
+      toNano(1.2), // minmum for election
+      [toNano(1.871), toNano(1.7348)], // current pool balances
       [toNano(1.2), toNano(1.2)] // minPoolStakes
     )
     expect(result_five).to.eql([toNano(1.2), toNano(1.2)])
@@ -142,7 +136,6 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
       toNano(5.5), // to stake
       toNano(5), // minmum for election
       [toNano(5), toNano(10)], // current pool balances
-      [toNano(5), toNano(10)], // current user stakes
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_six).to.eql([toNano(5.5), toNano(0)])
@@ -150,14 +143,14 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
 
   it('should distribute stake if only one pool is below minimum', () => {
     // activate pool two with 500 and the remainer (500) split between two pools
-    const result = fn(1000n, 1000n, [1500n, 500n], [0n, 0n], minPoolStakes)
+    const result = fn(1000n, 1000n, [1500n, 500n], minPoolStakes)
     expect(result).to.eql([250n, 750n])
 
-    const result_two = fn(1000n, 1000n, [500n, 1500n], [0n, 0n], minPoolStakes)
+    const result_two = fn(1000n, 1000n, [500n, 1500n], minPoolStakes)
     expect(result_two).to.eql([750n, 250n])
 
     // ^^ at edge
-    const result_three = fn(500n, 1000n, [500n, 1500n], [0n, 0n], minPoolStakes)
+    const result_three = fn(500n, 1000n, [500n, 1500n], minPoolStakes)
     expect(result_three).to.eql([500n, 0n])
 
     // if there is not enough to activate pool two, split stakes between
@@ -168,21 +161,21 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // so that the other staker has a chance to bring pool one in the next
     // staking action but at the same time user can still earn reawards from the
     // active pool (half of his stake)
-    const result_four = fn(300n, 1000n, [500n, 1500n], [0n, 0n], minPoolStakes)
+    const result_four = fn(300n, 1000n, [500n, 1500n], minPoolStakes)
     expect(result_four).to.eql([150n, 150n])
 
-    const result_five = fn(300n, 1000n, [1500n, 500n], [0n, 0n], minPoolStakes)
+    const result_five = fn(300n, 1000n, [1500n, 500n], minPoolStakes)
     expect(result_five).to.eql([150n, 150n])
   })
 
   it('should distribute stake if both pools are below minimum', () => {
     // there is no chance to make both pools active, fill the one with
     // highest stake
-    const result = fn(150n, 1000n, [300n, 400n], [0n, 0n], minPoolStakes)
+    const result = fn(150n, 1000n, [300n, 400n], minPoolStakes)
     expect(result).to.eql([0n, 150n])
 
     // ^^ same case as but reversed pool stakes
-    const result_reverse = fn(150n, 1000n, [400n, 300n], [0n, 0n], minPoolStakes)
+    const result_reverse = fn(150n, 1000n, [400n, 300n], minPoolStakes)
     expect(result_reverse).to.eql([150n, 0n])
 
     // there is a chance to make second pool active
@@ -193,19 +186,19 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // below case that would 4150 (our of 10150) earning no rewards. In the
     // second case only 2075 doesn't earn rewards, but at least the portion of
     // it contributes to the inactive pool being elected with next staker
-    const result_two = fn(10150n, 10000n, [3000n, 4000n], [0n, 0n], minPoolStakes)
+    const result_two = fn(10150n, 10000n, [3000n, 4000n], minPoolStakes)
     expect(result_two).to.eql([2075n, 8075n])
 
     // there is a chance to make second pool active
     // strategy: as above ^^ but reversed the pools
-    const result_three = fn(650n, 1000n, [400n, 300n], [0n, 0n], minPoolStakes)
+    const result_three = fn(650n, 1000n, [400n, 300n], minPoolStakes)
     expect(result_three).to.eql([625n, 25n])
 
     // there is a chance to make both pools active, split the stake
     // strategy: fill both pools to the minStake and split the rest. This way
     // user stake will benefit from both pools (as both pools have been just
     // activated with his stake)
-    const result_four = fn(13150n, 10000n, [3000n, 4000n], [0n, 0n], minPoolStakes)
+    const result_four = fn(13150n, 10000n, [3000n, 4000n], minPoolStakes)
     expect(result_four).to.eql([7075n, 6075n])
   })
 })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -73,7 +73,7 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
   const fn = TonPoolStaker.calculateStakePoolAmount
   const minPoolStakes = [1n, 1n]
 
-  it('should equalize the user stake if both pools are above min', () => {
+  it('should equalize the pool stake if both pools are above min', () => {
     // strategy: both pools are above minStake, so our goal is to optimize the
     // balance for the pool stake
     const result = fn(1000n, 200n, [250n, 200n], minPoolStakes)


### PR DESCRIPTION
# TL;DR
Currently user can stake only to one pool at the time. This PR adds logic in which the stake is 'balanced' among the contracts.

The logic is tested via unittests. It may look a bit complicated since it takes into account, pool balance and minimum stake per deposit. Depending on the pool status it balances out things as fair as I thought it can be done.

# Test plan
```
# case 1: too little to stake, 1.2 is the minimum
$ npm run staking-cli -- ton tx delegate-pool 0.5 -c config.tonpool.testnet.json -s local
Error: amount is less than the minimum required stake

# case 2: too little for two pools so stake to one (based on the pool stake)
$ npm run staking-cli -- ton tx delegate-pool 1.2 -c config.tonpool.testnet.json -s local
Staking to the following contracts:
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.2 TON (1200000000 nanoTON)

# case 3: still not enough to stake with two pools, stake with one
$ npm run staking-cli -- ton tx delegate-pool 2 -c config.tonpool.testnet.json -s local
Staking to the following contracts:
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 2 TON (2000000000 nanoTON)

# case 4: enough to stake with 2 pools. In this condition there is already stake on two pools but it's too little to "balance the whole stake with 2.4" (so that the end stake post this transaction is the same on both pools)
$ npm run staking-cli -- ton tx delegate-pool 2.4 -c config.tonpool.testnet.json -s local -b
Staking to the following contracts:
* kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F with 1.2 TON (1200000000 nanoTON)   
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.2 TON (1200000000 nanoTON)

# case 5: now 2.6 is enough to balance out the pool! after this TX the user stake will be the same on both pools (1.232534702 + currently_stake_on_first = 1.367465298 + currently_stake_on_second)
$ npm run staking-cli -- ton tx delegate-pool 2.6 -c config.tonpool.testnet.json -s local -b
Staking to the following contracts:
* kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F with 1.232534702 TON (1232534702 nanoTON)
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.367465298 TON (1367465298 nanoTON)
```

Now test `strategy` controls:
```
# case 1: we see the stake being balances (aim to equalize stakes after the TX takes place)
$ npm run staking-cli -- ton tx delegate-pool 2.6 -c config.tonpool.testnet.json -s local -b -S balanced
Staking to the following contracts:
* kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F with 1.231852981 TON (1231852981 nanoTON)                                                                                  
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.368147019 TON (1368147019 nanoTON)

# case 2: explicilty split stake into two parts
$ npm run staking-cli -- ton tx delegate-pool 2.6 -c config.tonpool.testnet.json -s local -b -S split
Staking to the following contracts:
* kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F with 1.3 TON (1300000000 nanoTON)
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.3 TON (1300000000 nanoTON)

# case 3: we force the 'stake to single'
$ npm run staking-cli -- ton tx delegate-pool 2.6 -c config.tonpool.testnet.json -s local -b -S single
Staking to the following contracts:
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 2.6 TON (2600000000 nanoTON)

# case 4: we want to split 2.2 but that is not enough (we need 2.4). So fallback to single strategy
$ npm run staking-cli -- ton tx delegate-pool 2.2 -c config.tonpool.testnet.json -s local -b -S split
Staking to the following contracts:
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 2.2 TON (2200000000 nanoTON)
```

Real life test:
```
# note that the stake should be equalized after this transaction
$ npm run staking-cli -- ton tx delegate-pool 2.6 -c config.tonpool.testnet.json -s local -b
Staking to the following contracts:
* kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F with 1.231852981 TON (1231852981 nanoTON)
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.368147019 TON (1368147019 nanoTON)

https://testnet.tonviewer.com/transaction/4786547cbb4b68849e121910503e889b99cc36f4ad0f7e24c992d90e6532167b

# note that stake has been equalized (we get round 1.3 for both pools)
$ npm run staking-cli -- ton tx delegate-pool 2.6 -c config.tonpool.testnet.json -s local -b
Staking to the following contracts:  
* kQAHBakDk_E7qLlNQZxJDsqj_ruyAFpqarw85tO-c03fK26F with 1.3 TON (1300000000 nanoTON)   
* kQCltujow9Sq3ZVPPU6CYGfqwDxYwjlmFGZ1Wt0bAYebio4o with 1.3 TON (1300000000 nanoTON) 
```