### PR TITLE
upgrade cosmos and relevant signers

### DIFF
--- a/packages/cosmos/package.json
+++ b/packages/cosmos/package.json
@@ -34,14 +34,14 @@
   "dependencies": {
     "@chorus-one/signer": "^1.0.0",
     "@chorus-one/utils": "^1.0.1",
-    "@cosmjs/amino": "^0.32.3",
-    "@cosmjs/crypto": "^0.32.3",
-    "@cosmjs/encoding": "^0.32.3",
-    "@cosmjs/math": "^0.32.3",
-    "@cosmjs/proto-signing": "^0.32.3",
-    "@cosmjs/stargate": "^0.31.3",
+    "@cosmjs/amino": "^0.33.1",
+    "@cosmjs/crypto": "^0.33.1",
+    "@cosmjs/encoding": "^0.33.1",
+    "@cosmjs/math": "^0.33.1",
+    "@cosmjs/proto-signing": "^0.33.1",
+    "@cosmjs/stargate": "^0.33.1",
     "bignumber.js": "^9.1.2",
-    "cosmjs-types": "^0.5.2",
+    "cosmjs-types": "^0.9.0",
     "secp256k1": "^5.0.0"
   }
 }

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -15,27 +15,17 @@ import {
 } from '@cosmjs/stargate'
 import { accountFromAny, Account } from '@cosmjs/stargate'
 import { Any } from 'cosmjs-types/google/protobuf/any'
-import { TendermintClient, Tendermint37Client, Tendermint34Client } from '@cosmjs/tendermint-rpc'
+import { connectComet, CometClient } from '@cosmjs/tendermint-rpc'
 
 /** @ignore */
 export class CosmosClient extends StargateClient {
-  static async create (tmClient: TendermintClient, options: StargateClientOptions): Promise<CosmosClient> {
+  static async create (tmClient: CometClient, options: StargateClientOptions): Promise<CosmosClient> {
     return new CosmosClient(tmClient, options)
   }
 
   // source: @cosmjs/stargate/build/stargateclient.js
   static async connect (endpoint: string, options: StargateClientOptions): Promise<CosmosClient> {
-    // Tendermint/CometBFT 0.34/0.37 auto-detection. Starting with 0.37 we seem to get reliable versions again 🎉
-    // Using 0.34 as the fallback.
-    let tmClient: TendermintClient
-    const tm37Client = await Tendermint37Client.connect(endpoint)
-    const version = (await tm37Client.status()).nodeInfo.version
-    if (version.startsWith('0.37.')) {
-      tmClient = tm37Client
-    } else {
-      tm37Client.disconnect()
-      tmClient = await Tendermint34Client.connect(endpoint)
-    }
+    const tmClient = await connectComet(endpoint)
     return CosmosClient.create(tmClient, options)
   }
 
@@ -46,7 +36,7 @@ export class CosmosClient extends StargateClient {
     StakingExtension &
     TxExtension &
     DistributionExtension {
-    const tmClient = this.getTmClient()
+    const tmClient = this.getCometClient()
     if (!tmClient) {
       throw new Error('Tendermint client not available')
     }

--- a/packages/signer-cactus-cosmos/src/signer.ts
+++ b/packages/signer-cactus-cosmos/src/signer.ts
@@ -50,11 +50,11 @@ export class CactusCosmosSigner {
 
     const { signDoc }: CosmosSigningData = signerData.data
 
-    await this.signer.signAmino(signDoc.chain_id, signerAddress, signDoc)
+    const signingResponse = await this.signer.signAmino(signDoc.chain_id, signerAddress, signDoc)
 
-    // NOTE: This is a dummy signature
-    // Cactus extension signs and broadcasts transactions on their own
-    const rawSig = Uint8Array.from(Buffer.from("DEADC0DE".repeat(8)))
+    const signature = signingResponse.signature.signature
+    const rawSig = Uint8Array.from(Buffer.from(signature, 'base64'))
+
     const sig = {
       fullSig: Buffer.from(rawSig).toString('hex'),
       r: Buffer.from(rawSig.subarray(0, 32)).toString('hex'),

--- a/packages/signer-cactus-cosmos/src/signer.ts
+++ b/packages/signer-cactus-cosmos/src/signer.ts
@@ -50,13 +50,13 @@ export class CactusCosmosSigner {
 
     const { signDoc }: CosmosSigningData = signerData.data
 
-    const signingResponse = await this.signer.signAmino(signDoc.chain_id, signerAddress, signDoc)
+    await this.signer.signAmino(signDoc.chain_id, signerAddress, signDoc)
 
-    const signature = signingResponse.signature.signature
-    const rawSig = Uint8Array.from(Buffer.from(signature, 'base64'))
-
+    // NOTE: This is a dummy signature
+    // Cactus extension signs and broadcasts transactions on their own
+    const rawSig = Uint8Array.from(Buffer.from("DEADC0DE".repeat(8)))
     const sig = {
-      fullSig: signature,
+      fullSig: Buffer.from(rawSig).toString('hex'),
       r: Buffer.from(rawSig.subarray(0, 32)).toString('hex'),
       s: Buffer.from(rawSig.subarray(32, 64)).toString('hex'),
       v: undefined

--- a/packages/signer-cactus-cosmos/src/types.d.ts
+++ b/packages/signer-cactus-cosmos/src/types.d.ts
@@ -10,8 +10,20 @@ export interface Key {
   isNanoLedger: boolean
 }
 
+export interface SignAminoResponse {
+    signature: {
+        signature: string
+        pub_key: {
+            type: string
+            value: string
+        }
+    }
+
+    signed: any
+}
+
 export interface CactusLinkCosmos {
   getKey(chainId: string): Promise<Key>
 
-  signAmino(chainId: string, signer: string, signDoc: any): Promise<string>
+  signAmino(chainId: string, signer: string, signDoc: any): Promise<SignAminoResponse>
 }

--- a/packages/signer-cactus-cosmos/src/types.d.ts
+++ b/packages/signer-cactus-cosmos/src/types.d.ts
@@ -10,13 +10,8 @@ export interface Key {
   isNanoLedger: boolean
 }
 
-export interface AminoSignResponse {
-  signed: any
-  signature: any
-}
-
 export interface CactusLinkCosmos {
   getKey(chainId: string): Promise<Key>
 
-  signAmino(chainId: string, signer: string, signDoc: any): Promise<AminoSignResponse>
+  signAmino(chainId: string, signer: string, signDoc: any): Promise<string>
 }

--- a/packages/signer-keplr/src/signer.ts
+++ b/packages/signer-keplr/src/signer.ts
@@ -43,13 +43,19 @@ export class KeplrSigner {
 
     const { signDoc }: CosmosSigningData = signerData.data
 
-    const signingResponse = await this.signer.signAmino(signDoc.chain_id, signerAddress, signDoc)
+    // if we allow to change the fees, the signature will be invalid as the
+    // wallet will change the signDoc
+    const signingResponse = await this.signer.signAmino(signDoc.chain_id, signerAddress, signDoc, {
+        preferNoSetFee: true,
+        preferNoSetMemo: true,
+        disableBalanceCheck: false
+    })
 
     const signature = signingResponse.signature.signature
     const rawSig = Uint8Array.from(Buffer.from(signature, 'base64'))
 
     const sig = {
-      fullSig: signature,
+      fullSig: Buffer.from(rawSig).toString('hex'),
       r: Buffer.from(rawSig.subarray(0, 32)).toString('hex'),
       s: Buffer.from(rawSig.subarray(32, 64)).toString('hex'),
       v: undefined


### PR DESCRIPTION
# TL;DR
1. deps update - cosmos nodes moved forward with new types that are not in older version. The upgrade fixes the broadcast return message parsing
2. cactus - the `signAmino` fix
3. keplr - the wallet attempts to update the txfees which breaks the signature (signs smth different), plus minor fix on the signature format