### PR TITLE
Update forking URL in hardhat config

### DIFF
--- a/packages/ethereum/test/lib/hardhat.json
+++ b/packages/ethereum/test/lib/hardhat.json
@@ -3,7 +3,7 @@
   "networks": {
     "hardhat": {
       "forking": {
-        "url": "https://eth.merkle.io"
+        "url": "https://ethereum-rpc.publicnode.com"
       },
       "accounts": [
         {


### PR DESCRIPTION
Ethereum tests are failing due to the rpc we're using in testing