### PR TITLE
cosmos: support testnets in configurator

### DIFF
--- a/packages/cosmos/package.json
+++ b/packages/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/cosmos",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "All-in-one toolkit for building staking dApps on Cosmos SDK based networks",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json"

--- a/packages/cosmos/src/configurator.ts
+++ b/packages/cosmos/src/configurator.ts
@@ -20,8 +20,9 @@ export class CosmosConfigurator {
    * @returns Returns an CosmosNetworkConfig object
    */
   static async genNetworkConfig (network: string, gas?: number, gasPrice?: string): Promise<CosmosNetworkConfig> {
+    const chainPath = network.includes('testnet') ? `testnets/` : ''
     const chainResponse = await fetch(
-      `https://raw.githubusercontent.com/cosmos/chain-registry/master/${network}/chain.json`
+      `https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainPath}${network}/chain.json`
     )
     if (!chainResponse.ok) {
       throw new Error(`Failed to fetch chain.json: ${chainResponse.statusText}`)
@@ -90,8 +91,9 @@ export class CosmosConfigurator {
   }
 
   private static async getAssetList (network: string): Promise<AssetList> {
+    const chainPath = network.includes('testnet') ? `testnets/` : ''
     const assetResponse = await fetch(
-      `https://raw.githubusercontent.com/cosmos/chain-registry/master/${network}/assetlist.json`
+      `https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainPath}${network}/assetlist.json`
     )
     if (!assetResponse.ok) {
       throw new Error(`Failed to fetch assetlist.json: ${assetResponse.statusText}`)


### PR DESCRIPTION
 # TL;DR
all testnets have `testnet` in the chain name, so it's a safe assumption to prefix the path. See:
https://github.com/cosmos/chain-registry/tree/master/testnets