### PR TITLE
Fix TON header request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9236,7 +9236,7 @@
     },
     "packages/ton": {
       "name": "@chorus-one/ton",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/ton",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "All-in-one tooling for building staking dApps on TON",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json"

--- a/packages/ton/src/TonBaseStaker.ts
+++ b/packages/ton/src/TonBaseStaker.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosAdapter, AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosAdapter, AxiosError, AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import type { Signer } from '@chorus-one/signer'
 import type {
   TonNetworkConfig,
@@ -178,7 +178,13 @@ export class TonBaseStaker {
       while (retries <= maxRetries) {
         try {
           // Send the request using the default adapter
-          return await defaultAdapter(config)
+          return await defaultAdapter({
+            ...config,
+            headers: AxiosHeaders.from({
+              ...(config.headers || {}),
+              'Content-Type': 'application/json'
+            })
+          })
         } catch (err) {
           const error = err as AxiosError
 


### PR DESCRIPTION
Issue: https://github.com/ChorusOne/chorus-one-sdk/issues/58

Bug added on: https://github.com/ChorusOne/chorus-one-sdk/commit/ad330dc3732d180fae06f05ca495992967915b77

The API expected the header `Content-Type: application/json` , but with the new config of the httpAdapter the header is set to `content-type: text/plain;charset=UTF-8`

Version 2.0.0 it's the last working version.