### PR TITLE
Include minElectionStake and minUserStake validation on TON SDK

### DIFF
--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -232,14 +232,14 @@ export class TonPoolStaker extends TonBaseStaker {
       const { minElectionStake, currentPoolBalances, userMaxUnstakeAmounts, userCurrentWithdrawals } =
         await this.getPoolDataForDelegator(delegatorAddress, validatorAddresses)
 
-      const unstakeAmountPerPool = TonPoolStaker.calculateUnstakePoolAmount({
-        amount: toNano(amount),
+      const unstakeAmountPerPool = TonPoolStaker.calculateUnstakePoolAmount(
+        toNano(amount),
         minElectionStake,
         currentPoolBalances,
         userMaxUnstakeAmounts,
         userCurrentWithdrawals,
-        userMinStake: [poolParamsData[0].minStake, poolParamsData[1].minStake]
-      })
+        [poolParamsData[0].minStake, poolParamsData[1].minStake]
+      )
 
       if (unstakeAmountPerPool[0] + unstakeAmountPerPool[1] !== toNano(amount)) {
         throw new Error('unstake amount does not match the requested amount')
@@ -539,21 +539,14 @@ export class TonPoolStaker extends TonBaseStaker {
    *    This avoids state synchronization issues by letting the contract handle the exact amounts
    */
   /** @ignore */
-  static calculateUnstakePoolAmount({
-    amount,
-    minElectionStake,
-    currentPoolBalances,
-    userMaxUnstakeAmounts,
-    userCurrentWithdrawals,
-    userMinStake
-  }: {
-    amount: bigint // amount to unstake
-    minElectionStake: bigint // minimum stake for participation (to be in the set)
-    currentPoolBalances: [bigint, bigint] // current stake balances of the pools
-    userMaxUnstakeAmounts: [bigint, bigint] // maximum user stake that can be unstaked from the pools
-    userCurrentWithdrawals: [bigint, bigint] // current user withdrawals from the pools
+  static calculateUnstakePoolAmount(
+    amount: bigint, // amount to unstake
+    minElectionStake: bigint, // minimum stake for participation (to be in the set)
+    currentPoolBalances: [bigint, bigint], // current stake balances of the pools
+    userMaxUnstakeAmounts: [bigint, bigint], // maximum user stake that can be unstaked from the pools
+    userCurrentWithdrawals: [bigint, bigint], // current user withdrawals from the pools
     userMinStake: [bigint, bigint] // minimum user stake to keep the pool active
-  }): [bigint, bigint] {
+  ): [bigint, bigint] {
     const [balancePool1, balancePool2] = currentPoolBalances
     const [userMaxUnstake1, userMaxUnstake2] = userMaxUnstakeAmounts
     const [userCurrentWithdrawals1, userCurrentWithdrawals2] = userCurrentWithdrawals
@@ -622,18 +615,6 @@ export class TonPoolStaker extends TonBaseStaker {
     // userMaxUnstakeToKeepAboveMin1, remainingFromPool2 (>minPoolStake || maxUserUnstake)
 
     // TODO: create function to return valid ranges for unstake.
-
-    console.log({
-      amount: fromNano(amount),
-      pools: pools.map((pool) => ({
-        ...pool,
-        balance: fromNano(pool.balance),
-        userCurrentWithdrawals: fromNano(pool.userCurrentWithdrawals),
-        userMaxUnstakeAbsolute: fromNano(pool.userMaxUnstakeAbsolute),
-        userMaxUnstakeToKeepPoolActive: fromNano(pool.userMaxUnstakeToKeepPoolActive),
-        userMaxUnstakeToKeepPoolAboveMin: fromNano(pool.userMaxUnstakeToKeepPoolAboveMin)
-      }))
-    })
 
     // Strategy 1: Try to keep both pools active
     if (pools[0].userMaxUnstakeToKeepPoolActive + pools[1].userMaxUnstakeToKeepPoolActive >= amount) {

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -653,7 +653,7 @@ export class TonPoolStaker extends TonBaseStaker {
       return result
     }
 
-    // Strategy 2: Keep pool 0 active
+    // Strategy 2: Keep pool with highest balance active
     if (pools[0].userMaxUnstakeToKeepPoolActive + pools[1].userMaxUnstakeToKeepPoolAboveMin >= amount) {
       const fromPool0 =
         amount <= pools[0].userMaxUnstakeToKeepPoolActive ? amount : pools[0].userMaxUnstakeToKeepPoolActive
@@ -664,7 +664,7 @@ export class TonPoolStaker extends TonBaseStaker {
       return result
     }
 
-    // Strategy 3: Keep pool 0 active
+    // Strategy 2: Keep pool with highest balance active
     if (
       pools[0].userMaxUnstakeToKeepPoolActive + pools[1].userMaxUnstakeAbsolute >= amount &&
       pools[1].userMaxUnstakeAbsolute <= amount // The user can't partially unstake the userMaxUnstakeAbsolute, so the user have to unstake all and the remaining amount must come from userMaxUnstakeToKeepPoolActive
@@ -677,7 +677,7 @@ export class TonPoolStaker extends TonBaseStaker {
       return result
     }
 
-    // Strategy 4: Keep pool 1 active
+    // Strategy 3: Keep pool with lowest balance active
     if (pools[1].userMaxUnstakeToKeepPoolActive + pools[0].userMaxUnstakeToKeepPoolAboveMin >= amount) {
       const fromPool1 =
         amount <= pools[1].userMaxUnstakeToKeepPoolActive ? amount : pools[1].userMaxUnstakeToKeepPoolActive
@@ -688,7 +688,7 @@ export class TonPoolStaker extends TonBaseStaker {
       return result
     }
 
-    // Strategy 5: Keep pool 1 active
+    // Strategy 3: Keep pool with lowest balance active
     if (
       pools[1].userMaxUnstakeToKeepPoolActive + pools[0].userMaxUnstakeAbsolute >= amount &&
       pools[0].userMaxUnstakeAbsolute <= amount

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -565,7 +565,7 @@ export class TonPoolStaker extends TonBaseStaker {
       poolMinStake: bigint,
       userWithdraw: bigint
     ): PoolInfo => {
-      // userStake = pending depositing + balance
+      // userStaked = pending depositing + balance
       const userStaked = userMaxUnstake - userWithdraw
 
       const maxUnstakeKeepPoolAboveMin = (userStaked > poolMinStake ? userStaked - poolMinStake : 0n) + userWithdraw

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -548,8 +548,8 @@ export class TonPoolStaker extends TonBaseStaker {
       index: 0 | 1
       totalBalance: bigint
       maxUnstakeAll: bigint
-      maxUnstakeKeepingPoolActive: bigint
-      maxUnstakeKeepingAboveMinimum: bigint
+      maxUnstakeKeepPoolActive: bigint
+      maxUnstakeKeepAboveMinimum: bigint
     }
 
     const buildPoolInfo = (
@@ -561,14 +561,14 @@ export class TonPoolStaker extends TonBaseStaker {
     ): PoolInfo => {
       const userDepositingAndAvailableWithdraw = userMaxUnstake - userCurrentBalance
 
-      const maxUnstakeKeepingActive = minBigInt(
+      const maxUnstakeKeepActive = minBigInt(
         (poolBalance > minimumElectionStake ? poolBalance - minimumElectionStake : 0n) +
           userDepositingAndAvailableWithdraw,
         (userCurrentBalance > userMinStake ? userCurrentBalance - userMinStake : 0n) +
           userDepositingAndAvailableWithdraw
       )
 
-      const maxUnstakeKeepingAboveMin =
+      const maxUnstakeKeepAboveMin =
         (userCurrentBalance > userMinStake ? userCurrentBalance - userMinStake : 0n) +
         userDepositingAndAvailableWithdraw
 
@@ -576,8 +576,8 @@ export class TonPoolStaker extends TonBaseStaker {
         index,
         totalBalance: poolBalance,
         maxUnstakeAll: userMaxUnstake,
-        maxUnstakeKeepingPoolActive: maxUnstakeKeepingActive,
-        maxUnstakeKeepingAboveMinimum: maxUnstakeKeepingAboveMin
+        maxUnstakeKeepPoolActive: maxUnstakeKeepActive,
+        maxUnstakeKeepAboveMinimum: maxUnstakeKeepAboveMin
       }
     }
 
@@ -625,9 +625,9 @@ export class TonPoolStaker extends TonBaseStaker {
     if (
       attemptPartialUnstakeFromBothPools(
         highBalPol,
-        highBalPol.maxUnstakeKeepingPoolActive,
+        highBalPol.maxUnstakeKeepPoolActive,
         lowBalPol,
-        lowBalPol.maxUnstakeKeepingPoolActive
+        lowBalPol.maxUnstakeKeepPoolActive
       )
     )
       return unstakeAmounts
@@ -636,45 +636,45 @@ export class TonPoolStaker extends TonBaseStaker {
     if (
       attemptPartialUnstakeFromBothPools(
         highBalPol,
-        highBalPol.maxUnstakeKeepingPoolActive,
+        highBalPol.maxUnstakeKeepPoolActive,
         lowBalPol,
-        lowBalPol.maxUnstakeKeepingAboveMinimum
+        lowBalPol.maxUnstakeKeepAboveMinimum
       )
     )
       return unstakeAmounts
 
-    if (attemptCompleteUnstakeFromOnePool(lowBalPol, highBalPol, highBalPol.maxUnstakeKeepingPoolActive))
+    if (attemptCompleteUnstakeFromOnePool(lowBalPol, highBalPol, highBalPol.maxUnstakeKeepPoolActive))
       return unstakeAmounts
 
     // Strategy 3: Keep lower balance pool active, deactivate higher balance pool
     if (
       attemptPartialUnstakeFromBothPools(
         lowBalPol,
-        lowBalPol.maxUnstakeKeepingPoolActive,
+        lowBalPol.maxUnstakeKeepPoolActive,
         highBalPol,
-        highBalPol.maxUnstakeKeepingAboveMinimum
+        highBalPol.maxUnstakeKeepAboveMinimum
       )
     )
       return unstakeAmounts
 
-    if (attemptCompleteUnstakeFromOnePool(highBalPol, lowBalPol, lowBalPol.maxUnstakeKeepingPoolActive))
+    if (attemptCompleteUnstakeFromOnePool(highBalPol, lowBalPol, lowBalPol.maxUnstakeKeepPoolActive))
       return unstakeAmounts
 
     // Strategy 4: Deactivate both pools but maintain minimum stakes
     if (
       attemptPartialUnstakeFromBothPools(
         highBalPol,
-        highBalPol.maxUnstakeKeepingAboveMinimum,
+        highBalPol.maxUnstakeKeepAboveMinimum,
         lowBalPol,
-        lowBalPol.maxUnstakeKeepingAboveMinimum
+        lowBalPol.maxUnstakeKeepAboveMinimum
       )
     )
       return unstakeAmounts
 
-    if (attemptCompleteUnstakeFromOnePool(lowBalPol, highBalPol, highBalPol.maxUnstakeKeepingAboveMinimum))
+    if (attemptCompleteUnstakeFromOnePool(lowBalPol, highBalPol, highBalPol.maxUnstakeKeepAboveMinimum))
       return unstakeAmounts
 
-    if (attemptCompleteUnstakeFromOnePool(highBalPol, lowBalPol, lowBalPol.maxUnstakeKeepingAboveMinimum))
+    if (attemptCompleteUnstakeFromOnePool(highBalPol, lowBalPol, lowBalPol.maxUnstakeKeepAboveMinimum))
       return unstakeAmounts
 
     // Strategy 5: Complete withdrawal from both pools

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -34,7 +34,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to a TON nominator pool staking transaction.
    */
-  async buildStakeTx(params: {
+  async buildStakeTx (params: {
     delegatorAddress: string
     validatorAddressPair: [string, string]
     amount: string
@@ -166,7 +166,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to a TON nominator pool staking transaction.
    */
-  async buildUnstakeTx(params: {
+  async buildUnstakeTx (params: {
     delegatorAddress: string
     validatorAddressPair: [string, string]
     amount: string
@@ -275,7 +275,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to the staking information for the specified delegator.
    */
-  async getStake(params: { delegatorAddress: string; validatorAddress: string }) {
+  async getStake (params: { delegatorAddress: string; validatorAddress: string }) {
     const { delegatorAddress, validatorAddress } = params
     const client = this.getClient()
 
@@ -299,7 +299,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to the staking information for the specified pool.
    */
-  async getPoolParams(params: { validatorAddress: string }) {
+  async getPoolParams (params: { validatorAddress: string }) {
     const result = await this.getPoolParamsUnformatted(params)
 
     return {
@@ -323,7 +323,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns A promise that resolves to an object containing the transaction status.
    */
-  async getTxStatus(params: { address: string; txHash: string; limit?: number }): Promise<TonTxStatus> {
+  async getTxStatus (params: { address: string; txHash: string; limit?: number }): Promise<TonTxStatus> {
     const transaction = await this.getTransactionByHash(params)
 
     if (transaction === undefined) {
@@ -345,7 +345,7 @@ export class TonPoolStaker extends TonBaseStaker {
     return this.matchTransactionStatus(transaction)
   }
 
-  private async getPoolParamsUnformatted(params: { validatorAddress: string }) {
+  private async getPoolParamsUnformatted (params: { validatorAddress: string }) {
     const { validatorAddress } = params
     const client = this.getClient()
     const response = await client.runMethod(Address.parse(validatorAddress), 'get_params', [])
@@ -367,7 +367,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  private async getPoolDataForDelegator(delegatorAddress: string, validatorAddresses: string[]) {
+  private async getPoolDataForDelegator (delegatorAddress: string, validatorAddresses: string[]) {
     const [poolStatus, userStake, minElectionStake] = await Promise.all([
       Promise.all(validatorAddresses.map((validatorAddress) => this.getPoolStatus(validatorAddress))),
       Promise.all(validatorAddresses.map((validatorAddress) => this.getStake({ delegatorAddress, validatorAddress }))),
@@ -398,7 +398,7 @@ export class TonPoolStaker extends TonBaseStaker {
     }
   }
 
-  async getElectionMinStake(): Promise<bigint> {
+  async getElectionMinStake (): Promise<bigint> {
     // elector contract address
     const elections = await this.getPastElections('Ef8zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM0vF')
 
@@ -415,7 +415,7 @@ export class TonPoolStaker extends TonBaseStaker {
     return minStake
   }
 
-  async getPoolStatus(validatorAddress: string): Promise<PoolStatus> {
+  async getPoolStatus (validatorAddress: string): Promise<PoolStatus> {
     const client = this.getClient()
     const provider = client.provider(Address.parse(validatorAddress))
     const res = await provider.get('get_pool_status', [])
@@ -429,16 +429,16 @@ export class TonPoolStaker extends TonBaseStaker {
     }
   }
 
-  async getPastElections(electorContractAddress: string): Promise<Election[]> {
+  async getPastElections (electorContractAddress: string): Promise<Election[]> {
     const client = this.getClient()
     const provider = client.provider(Address.parse(electorContractAddress))
     const res = await provider.get('past_elections', [])
 
     const FrozenDictValue: DictionaryValue<FrozenSet> = {
-      serialize(_src: FrozenSet, _builder: Builder) {
+      serialize (_src: FrozenSet, _builder: Builder) {
         throw Error('not implemented')
       },
-      parse(src: Slice): FrozenSet {
+      parse (src: Slice): FrozenSet {
         const address = new Address(-1, src.loadBuffer(32))
         const weight = src.loadUintBig(64)
         const stake = src.loadCoins()
@@ -478,7 +478,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  static selectPool(
+  static selectPool (
     minStake: bigint, // minimum stake for participation (to be in the set)
     currentBalances: [bigint, bigint] // current stake balances of the pools
   ): number {
@@ -501,7 +501,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  static selectStrategy(
+  static selectStrategy (
     preferredStrategy: string | undefined,
     amount: bigint,
     totalValidators: number,
@@ -532,7 +532,7 @@ export class TonPoolStaker extends TonBaseStaker {
    * Calculates optimal unstake amounts from two pools.
    * Tries strategies in order: keep both active → keep one active → deactivate both
    */
-  static calculateUnstakePoolAmount(
+  static calculateUnstakePoolAmount (
     requestedAmount: bigint,
     minimumElectionStake: bigint,
     [pool1Balance, pool2Balance]: [bigint, bigint],
@@ -688,7 +688,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  static calculateStakePoolAmount(
+  static calculateStakePoolAmount (
     amount: bigint, // amount to stake
     minStake: bigint, // minimum stake for participation (to be in the set)
     currentPoolBalances: [bigint, bigint], // current stake balances of the pools

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -34,7 +34,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to a TON nominator pool staking transaction.
    */
-  async buildStakeTx(params: {
+  async buildStakeTx (params: {
     delegatorAddress: string
     validatorAddressPair: [string, string]
     amount: string
@@ -166,7 +166,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to a TON nominator pool staking transaction.
    */
-  async buildUnstakeTx(params: {
+  async buildUnstakeTx (params: {
     delegatorAddress: string
     validatorAddressPair: [string, string]
     amount: string
@@ -275,7 +275,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to the staking information for the specified delegator.
    */
-  async getStake(params: { delegatorAddress: string; validatorAddress: string }) {
+  async getStake (params: { delegatorAddress: string; validatorAddress: string }) {
     const { delegatorAddress, validatorAddress } = params
     const client = this.getClient()
 
@@ -299,7 +299,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns Returns a promise that resolves to the staking information for the specified pool.
    */
-  async getPoolParams(params: { validatorAddress: string }) {
+  async getPoolParams (params: { validatorAddress: string }) {
     const result = await this.getPoolParamsUnformatted(params)
 
     return {
@@ -323,7 +323,7 @@ export class TonPoolStaker extends TonBaseStaker {
    *
    * @returns A promise that resolves to an object containing the transaction status.
    */
-  async getTxStatus(params: { address: string; txHash: string; limit?: number }): Promise<TonTxStatus> {
+  async getTxStatus (params: { address: string; txHash: string; limit?: number }): Promise<TonTxStatus> {
     const transaction = await this.getTransactionByHash(params)
 
     if (transaction === undefined) {
@@ -345,7 +345,7 @@ export class TonPoolStaker extends TonBaseStaker {
     return this.matchTransactionStatus(transaction)
   }
 
-  private async getPoolParamsUnformatted(params: { validatorAddress: string }) {
+  private async getPoolParamsUnformatted (params: { validatorAddress: string }) {
     const { validatorAddress } = params
     const client = this.getClient()
     const response = await client.runMethod(Address.parse(validatorAddress), 'get_params', [])
@@ -367,7 +367,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  private async getPoolDataForDelegator(delegatorAddress: string, validatorAddresses: string[]) {
+  private async getPoolDataForDelegator (delegatorAddress: string, validatorAddresses: string[]) {
     const [poolStatus, userStake, minElectionStake] = await Promise.all([
       Promise.all(validatorAddresses.map((validatorAddress) => this.getPoolStatus(validatorAddress))),
       Promise.all(validatorAddresses.map((validatorAddress) => this.getStake({ delegatorAddress, validatorAddress }))),
@@ -398,7 +398,7 @@ export class TonPoolStaker extends TonBaseStaker {
     }
   }
 
-  async getElectionMinStake(): Promise<bigint> {
+  async getElectionMinStake (): Promise<bigint> {
     // elector contract address
     const elections = await this.getPastElections('Ef8zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM0vF')
 
@@ -415,7 +415,7 @@ export class TonPoolStaker extends TonBaseStaker {
     return minStake
   }
 
-  async getPoolStatus(validatorAddress: string): Promise<PoolStatus> {
+  async getPoolStatus (validatorAddress: string): Promise<PoolStatus> {
     const client = this.getClient()
     const provider = client.provider(Address.parse(validatorAddress))
     const res = await provider.get('get_pool_status', [])
@@ -429,16 +429,16 @@ export class TonPoolStaker extends TonBaseStaker {
     }
   }
 
-  async getPastElections(electorContractAddress: string): Promise<Election[]> {
+  async getPastElections (electorContractAddress: string): Promise<Election[]> {
     const client = this.getClient()
     const provider = client.provider(Address.parse(electorContractAddress))
     const res = await provider.get('past_elections', [])
 
     const FrozenDictValue: DictionaryValue<FrozenSet> = {
-      serialize(_src: FrozenSet, _builder: Builder) {
+      serialize (_src: FrozenSet, _builder: Builder) {
         throw Error('not implemented')
       },
-      parse(src: Slice): FrozenSet {
+      parse (src: Slice): FrozenSet {
         const address = new Address(-1, src.loadBuffer(32))
         const weight = src.loadUintBig(64)
         const stake = src.loadCoins()
@@ -478,7 +478,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  static selectPool(
+  static selectPool (
     minStake: bigint, // minimum stake for participation (to be in the set)
     currentBalances: [bigint, bigint] // current stake balances of the pools
   ): number {
@@ -501,7 +501,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  static selectStrategy(
+  static selectStrategy (
     preferredStrategy: string | undefined,
     amount: bigint,
     totalValidators: number,
@@ -538,7 +538,7 @@ export class TonPoolStaker extends TonBaseStaker {
    * TODO: Add `getValidUnstakeRanges()` method to help integrators validate amounts upfront by knowing the valid amounts to unstake.
    *
    */
-  static calculateUnstakePoolAmount(
+  static calculateUnstakePoolAmount (
     amount: bigint, // amount to unstake
     minElectionStake: bigint, // minimum stake for participation (to be in the set)
     [pool1Balance, pool2Balance]: [bigint, bigint], // current stake balances of the pools
@@ -692,7 +692,7 @@ export class TonPoolStaker extends TonBaseStaker {
   }
 
   /** @ignore */
-  static calculateStakePoolAmount(
+  static calculateStakePoolAmount (
     amount: bigint, // amount to stake
     minStake: bigint, // minimum stake for participation (to be in the set)
     currentPoolBalances: [bigint, bigint], // current stake balances of the pools

--- a/packages/ton/src/utils.ts
+++ b/packages/ton/src/utils.ts
@@ -1,0 +1,3 @@
+export function minBigInt(a: bigint, b: bigint): bigint {
+  return a < b ? a : b
+}

--- a/packages/ton/src/utils.ts
+++ b/packages/ton/src/utils.ts
@@ -1,3 +1,3 @@
-export function minBigInt(a: bigint, b: bigint): bigint {
+export function minBigInt (a: bigint, b: bigint): bigint {
   return a < b ? a : b
 }

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -21,7 +21,7 @@ describe('TonPoolStaker_selectPool', () => {
 })
 
 // Order os tries userMaxUnstakeToKeepPoolActive -> userMaxUnstakeToKeepPoolAboveMin -> userMaxUnstakeAbsolute
-describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
+describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const fn = TonPoolStaker.calculateUnstakePoolAmount
   const minElectionStake = 10n
 

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -25,7 +25,7 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const fn = TonPoolStaker.calculateUnstakePoolAmount
   const minElectionStake = 10n
 
-  describe('should keep both pools active, amount < userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
+  describe('should keep both pools active, amount <= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
     // pool1: userMaxUnstakeToKeepPoolActive (5n) < userMaxUnstakeToKeepPoolAboveMin (10n)
     // pool2: userMaxUnstakeToKeepPoolActive (10n) == userMaxUnstakeToKeepPoolAboveMin (10n)
     // balance 1 < balance 2
@@ -56,7 +56,7 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
     // })
   })
 
-  describe('should disable pool with lowest balance, amount > userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
+  describe('should disable pool with lowest balance, amount >= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
     it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeToKeepPoolAboveMin fully', () => {
       const result = fn(8n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
       expect(result).to.deep.equal([3n, 5n])
@@ -78,7 +78,7 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
     })
   })
 
-  describe('should disable pool with highest balance, amount > userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
+  describe('should disable pool with highest balance, amount >= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
     it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeToKeepPoolActive fully', () => {
       const result = fn(9n, minElectionStake, [13n, 12n], [10n, 5n], [3n, 3n], [10n, 5n])
       expect(result).to.deep.equal([7n, 2n])
@@ -102,7 +102,7 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
     })
 
     it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeToKeepPoolAboveMin fully', () => {
-      const result = fn(8n, minElectionStake, [15n, 15n], [12n, 12n], [8n, 8n], [12n, 12n])
+      const result = fn(8n, minElectionStake, [13n, 13n], [12n, 12n], [8n, 8n], [12n, 12n])
       expect(result).to.deep.equal([4n, 4n])
     })
 

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -24,153 +24,163 @@ describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const fn = TonPoolStaker.calculateUnstakePoolAmount
   const minElectionStake = 10n
 
-  describe('should keep both pools active, amount <= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
-    // pool1: userMaxUnstakeToKeepPoolActive (5n) < userMaxUnstakeToKeepPoolAboveMin (10n)
-    // pool2: userMaxUnstakeToKeepPoolActive (10n) == userMaxUnstakeToKeepPoolAboveMin (10n)
+  describe('should keep both pools active, amount <= maxUnstakeKeepPool1Active + maxUnstakeKeepPool2Active', () => {
+    // pool1: maxUnstakeKeepPoolActive (5n) < maxUnstakeKeepPoolAboveMin (10n)
+    // pool2: maxUnstakeKeepPoolActive (10n) == maxUnstakeKeepPoolAboveMin (10n)
     // balance 1 < balance 2
-    it('should unstake userMaxUnstakeToKeepPoolActive partially, while prioritizing pool balance', () => {
-      const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [10n, 10n])
+    it('should unstake maxUnstakeKeepPoolActive partially, while prioritizing pool balance', () => {
+      const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
       expect(result).to.deep.equal([0n, 5n])
     })
 
-    // pool1: userMaxUnstakeToKeepPoolActive (5n) < userMaxUnstakeToKeepPoolAboveMin (10n)
-    // pool2: userMaxUnstakeToKeepPoolActive (10n) == userMaxUnstakeToKeepPoolAboveMin (10n)
-    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeToKeepPoolActive fully', () => {
-      const result = fn(15n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [10n, 10n])
+    // pool1: maxUnstakeKeepPoolActive (5n) < maxUnstakeKeepPoolAboveMin (10n)
+    // pool2: maxUnstakeKeepPoolActive (10n) == maxUnstakeKeepPoolAboveMin (10n)
+    it('should unstake maxUnstakeKeepPoolActive fully and maxUnstakeKeepPoolActive fully', () => {
+      const result = fn(15n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
       expect(result).to.deep.equal([5n, 10n])
     })
 
-    // pool1: userMaxUnstakeToKeepPoolActive (5n) > userMaxUnstakeToKeepPoolAboveMin (3n)
-    // pool2: userMaxUnstakeToKeepPoolActive (10n) > userMaxUnstakeToKeepPoolAboveMin (3n)
-    it('should unstake userMaxUnstakeToKeepPoolActive partially and userMaxUnstakeToKeepPoolAboveMin fully, when userMaxUnstakeToKeepPoolActive > userMaxUnstakeToKeepPoolAboveMin', () => {
-      const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [10n, 10n])
+    // pool1: maxUnstakeKeepPoolActive (5n) > maxUnstakeKeepPoolAboveMin (3n)
+    // pool2: maxUnstakeKeepPoolActive (10n) > maxUnstakeKeepPoolAboveMin (3n)
+    it('should unstake maxUnstakeKeepPoolActive partially and maxUnstakeKeepPoolAboveMin fully, when maxUnstakeKeepPoolActive > maxUnstakeKeepPoolAboveMin', () => {
+      const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [0n, 0n])
       expect(result).to.deep.equal([2n, 3n])
     })
   })
 
-  describe('should disable pool with lowest balance, amount >= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
-    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeToKeepPoolAboveMin fully', () => {
-      const result = fn(8n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
+  describe('should disable pool with lowest balance, amount >= maxUnstakeKeepPool1Active + maxUnstakeKeepPool2AboveMin', () => {
+    it('should unstake maxUnstakeKeepPoolActive fully and maxUnstakeKeepPoolAboveMin fully', () => {
+      const result = fn(8n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [0n, 0n])
       expect(result).to.deep.equal([3n, 5n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeToKeepPoolAboveMin partially', () => {
-      const result = fn(6n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
+    it('should unstake maxUnstakeKeepPoolActive fully and maxUnstakeKeepPoolAboveMin partially', () => {
+      const result = fn(6n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [0n, 0n])
       expect(result).to.deep.equal([3n, 3n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeAbsolute', () => {
-      const result = fn(13n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
+    it('should unstake maxUnstakeKeepPoolActive fully and userMaxUnstakeAbsolute', () => {
+      const result = fn(13n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [0n, 0n])
       expect(result).to.deep.equal([3n, 10n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolActive partially and userMaxUnstakeToKeepPoolAboveMin partially, when userMaxUnstakeToKeepPoolActive > userMaxUnstakeToKeepPoolAboveMin', () => {
-      const result = fn(7n, minElectionStake, [20n, 10n], [10n, 10n], [5n, 5n], [10n, 10n])
+    it('should unstake maxUnstakeKeepPoolActive partially and maxUnstakeKeepPoolAboveMin partially, when maxUnstakeKeepPoolActive > maxUnstakeKeepPoolAboveMin', () => {
+      const result = fn(7n, minElectionStake, [20n, 10n], [10n, 10n], [5n, 5n], [0n, 0n])
       expect(result).to.deep.equal([5n, 2n])
     })
   })
 
-  describe('should disable pool with highest balance, amount >= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeToKeepPoolActive fully', () => {
-      const result = fn(9n, minElectionStake, [13n, 12n], [10n, 5n], [3n, 3n], [10n, 5n])
+  describe('should disable pool with highest balance, amount >= maxUnstakeKeepPool1AboveMin + maxUnstakeKeepPool2Active', () => {
+    it('should unstake maxUnstakeKeepPoolAboveMin fully and maxUnstakeKeepPoolActive fully', () => {
+      const result = fn(9n, minElectionStake, [13n, 12n], [10n, 5n], [3n, 3n], [0n, 0n])
       expect(result).to.deep.equal([7n, 2n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin partially and userMaxUnstakeToKeepPoolActive fully', () => {
-      const result = fn(8n, minElectionStake, [13n, 12n], [10n, 4n], [1n, 1n], [10n, 4n])
+    it('should unstake maxUnstakeKeepPoolAboveMin partially and maxUnstakeKeepPoolActive fully', () => {
+      const result = fn(8n, minElectionStake, [13n, 12n], [10n, 4n], [1n, 1n], [0n, 0n])
       expect(result).to.deep.equal([6n, 2n])
     })
 
-    it('should unstake userMaxUnstakeAbsolute and userMaxUnstakeToKeepPoolActive fully', () => {
-      const result = fn(12n, minElectionStake, [13n, 12n], [10n, 4n], [1n, 1n], [10n, 4n])
+    it('should unstake userMaxUnstakeAbsolute and maxUnstakeKeepPoolActive fully', () => {
+      const result = fn(12n, minElectionStake, [13n, 12n], [10n, 4n], [1n, 1n], [0n, 0n])
       expect(result).to.deep.equal([10n, 2n])
     })
   })
 
   describe('should disable both pools', () => {
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeToKeepPoolAboveMin partially', () => {
-      const result = fn(10n, minElectionStake, [13n, 12n], [11n, 11n], [5n, 5n], [11n, 11n])
+    it('should unstake maxUnstakeKeepPoolAboveMin fully and maxUnstakeKeepPoolAboveMin partially', () => {
+      const result = fn(10n, minElectionStake, [13n, 12n], [11n, 11n], [5n, 5n], [0n, 0n])
       expect(result).to.deep.equal([6n, 4n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeToKeepPoolAboveMin fully', () => {
-      const result = fn(8n, minElectionStake, [13n, 13n], [12n, 12n], [8n, 8n], [12n, 12n])
+    it('should unstake maxUnstakeKeepPoolAboveMin fully and maxUnstakeKeepPoolAboveMin fully', () => {
+      const result = fn(8n, minElectionStake, [13n, 13n], [12n, 12n], [8n, 8n], [0n, 0n])
       expect(result).to.deep.equal([4n, 4n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeAbsolute', () => {
-      const result = fn(16n, minElectionStake, [15n, 15n], [12n, 12n], [8n, 8n], [12n, 12n])
+    it('should unstake maxUnstakeKeepPoolAboveMin fully and userMaxUnstakeAbsolute', () => {
+      const result = fn(16n, minElectionStake, [15n, 15n], [12n, 12n], [8n, 8n], [0n, 0n])
       expect(result).to.deep.equal([4n, 12n])
     })
   })
 
   describe('should unstake all', () => {
     it('should unstake userMaxUnstakeAbsolute and userMaxUnstakeAbsolute above minElectionStake', () => {
-      const result = fn(8n, minElectionStake, [32n, 40n], [5n, 3n], [0n, 0n], [5n, 3n])
+      const result = fn(8n, minElectionStake, [32n, 40n], [5n, 3n], [0n, 0n], [0n, 0n])
       expect(result).to.deep.equal([5n, 3n])
     })
 
     it('should unstake userMaxUnstakeAbsolute and userMaxUnstakeAbsolute bellow minElectionStake', () => {
-      const result = fn(10n, minElectionStake, [7n, 7n], [5n, 5n], [0n, 0n], [5n, 3n])
+      const result = fn(10n, minElectionStake, [7n, 7n], [5n, 5n], [0n, 0n], [0n, 0n])
       expect(result).to.deep.equal([5n, 5n])
     })
 
     it('should unstake userMaxUnstakeAbsolute and userMaxUnstakeAbsolute above userMinStake', () => {
-      const result = fn(24n, minElectionStake, [15n, 15n], [12n, 12n], [8n, 8n], [12n, 12n])
+      const result = fn(24n, minElectionStake, [15n, 15n], [12n, 12n], [8n, 8n], [0n, 0n])
       expect(result).to.deep.equal([12n, 12n])
     })
 
     it('should unstake userMaxUnstakeAbsolute and userMaxUnstakeAbsolute bellow userMinStake', () => {
-      const result = fn(4n, minElectionStake, [15n, 15n], [2n, 2n], [8n, 8n], [12n, 12n])
+      const result = fn(4n, minElectionStake, [15n, 15n], [2n, 2n], [8n, 8n], [0n, 0n])
       expect(result).to.deep.equal([2n, 2n])
     })
   })
 
   describe('should unstake when bellow minElectionStake', () => {
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin partially', () => {
-      const result = fn(1n, minElectionStake, [7n, 7n], [5n, 5n], [3n, 3n], [5n, 5n])
+    it('should unstake maxUnstakeKeepPoolAboveMin partially', () => {
+      const result = fn(1n, minElectionStake, [7n, 7n], [5n, 5n], [3n, 3n], [0n, 0n])
       expect(result).to.deep.equal([0n, 1n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolAboveMin fully', () => {
-      const result = fn(4n, minElectionStake, [7n, 7n], [5n, 5n], [3n, 3n], [5n, 5n])
+    it('should unstake maxUnstakeKeepPoolAboveMin fully', () => {
+      const result = fn(4n, minElectionStake, [7n, 7n], [5n, 5n], [3n, 3n], [0n, 0n])
       expect(result).to.deep.equal([2n, 2n])
     })
   })
 
   describe('should reject invalid amounts', () => {
-    it('should throw error if user wants to withdraw more than available', () => {
+    it('should reject when trying to unstake more than available', () => {
       expect(() => fn(21n, 10n, [20n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])).to.throw(
         'Requested amount exceeds available stakes'
       )
     })
 
-    it("should throw if user request an amount that's impossible to find a pair", () => {
-      expect(() => fn(10n, minElectionStake, [15n, 15n], [8n, 8n], [7n, 7n], [8n, 8n])).to.throw(
+    it('should reject when maxUnstakeToKeepPoolAboveMin is not enough', () => {
+      expect(() => fn(10n, minElectionStake, [15n, 15n], [8n, 8n], [7n, 7n], [0n, 0n])).to.throw(
         'No valid combination to unstake requested amount'
       )
     })
 
-    it('should user try to partially unstake bellow userMinBalance', () => {
-      expect(() => fn(7n, minElectionStake, [15n, 15n], [4n, 4n], [7n, 7n], [8n, 8n])).to.throw(
+    it('should reject when trying to partially withdraw pool bellow userMinStake', () => {
+      expect(() => fn(7n, minElectionStake, [15n, 15n], [4n, 4n], [7n, 7n], [0n, 0n])).to.throw(
+        'No valid combination to unstake requested amount'
+      )
+    })
+
+    it('should reject when trying to partially withdraw pool bellow userMinStake and userWithdraw is not enough', () => {
+      expect(() => fn(17n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])).to.throw(
         'No valid combination to unstake requested amount'
       )
     })
   })
 
-  describe('should allow partial withdraw when pool is bellow userMinStake and user has deposit and ready to withdraw amounts', () => {
-    // userBalance = [6n, 6n] < userMinStake = 7n
-    // userDepositingAndAvailableToWithdraw=[4n, 4n]
-    it('should withdraw all from one pool and the rest from depositing and ready to withdraw amounts', () => {
-      const result = fn(12n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
-      expect(result).to.deep.equal([10n, 2n])
+  describe('should allow partial withdraw when pool is bellow userMinStake and user has ready to withdraw amounts', () => {
+    // userStaked=[4n, 4n] < userMinStake = 7n
+    it('should unstake userWithdraw partially', () => {
+      const result = fn(2n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
+      expect(result).to.deep.equal([0n, 2n])
     })
 
-    // userBalance = [6n, 6n] < userMinStake = 7n
-    // userDepositingAndAvailableToWithdraw=[4n, 4n]
-    it('should withdraw partially the depositing and ready to withdraw amounts', () => {
+    // userStaked=[4n, 4n] < userMinStake = 7n
+    it('should unstake maxUnstakeAbsolute and userWithdraw fully', () => {
+      const result = fn(16n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
+      expect(result).to.deep.equal([10n, 6n])
+    })
+
+    // userStaked=[4n, 4n] < userMinStake = 7n
+    it('should unstake userWithdraw partially and userWithdraw fully', () => {
       const result = fn(7n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
-      expect(result).to.deep.equal([3n, 4n])
+      expect(result).to.deep.equal([1n, 6n])
     })
   })
 })
@@ -189,7 +199,7 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // the lower balance
     const result_tw = fn(
       toNano(5), // to stake
-      toNano(5), // minmum for election
+      toNano(5), // minimum for election
       [toNano(10), toNano(10)], // current pool balances
       [toNano(1), toNano(1)] // minPoolStakes
     )
@@ -199,7 +209,7 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // the lower balance
     const result_two = fn(
       toNano(3), // to stake
-      toNano(5), // minmum for election
+      toNano(5), // minimum for election
       [toNano(5), toNano(10)], // current pool balances
       [toNano(1), toNano(1)] // minPoolStakes
     )
@@ -208,29 +218,29 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // if the amount is enough to balance the stakes do it
     const result_three = fn(
       toNano(5), // to stake
-      toNano(5), // minmum for election
+      toNano(5), // minimum for election
       [toNano(5), toNano(10)], // current pool balances
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_three).to.eql([toNano(5), toNano(0)])
 
-    // if the remainder ( 6 - (6 - 1) = 1 ) divided evenlty (0.5) is not meeting
+    // if the remainder ( 6 - (6 - 1) = 1 ) divided evenly (0.5) is not meeting
     // the minimum stake, try to fill up the pool with the lower balance and
     // push the whole remainder to the other pool
     const result_four = fn(
       toNano(6), // to stake
-      toNano(5), // minmum for election
+      toNano(5), // minimum for election
       [toNano(5), toNano(10)], // current pool balances
       [toNano(1), toNano(1)] // minPoolStakes
     )
     expect(result_four).to.eql([toNano(5), toNano(1)])
 
-    // it's not possible to blance the stakes and keep the minimum stake
-    // so resign from blancing the pool stake and simply split the
+    // it's not possible to balance the stakes and keep the minimum stake
+    // so resign from balancing the pool stake and simply split the
     // amount between the pools
     const result_five = fn(
       toNano(2.4), // to stake
-      toNano(1.2), // minmum for election
+      toNano(1.2), // minimum for election
       [toNano(1.871), toNano(1.7348)], // current pool balances
       [toNano(1.2), toNano(1.2)] // minPoolStakes
     )
@@ -240,7 +250,7 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // with the lowest stake pool
     const result_six = fn(
       toNano(5.5), // to stake
-      toNano(5), // minmum for election
+      toNano(5), // minimum for election
       [toNano(5), toNano(10)], // current pool balances
       [toNano(1), toNano(1)] // minPoolStakes
     )
@@ -248,7 +258,7 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
   })
 
   it('should distribute stake if only one pool is below minimum', () => {
-    // activate pool two with 500 and the remainer (500) split between two pools
+    // activate pool two with 500 and the remainder (500) split between two pools
     const result = fn(1000n, 1000n, [1500n, 500n], minPoolStakes)
     expect(result).to.eql([250n, 750n])
 
@@ -262,10 +272,10 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // if there is not enough to activate pool two, split stakes between
     // active/inactive pool
     //
-    // strategy: user stake can't activae the pool two, so staking all to pool
+    // strategy: user stake can't activate the pool two, so staking all to pool
     // two doesn't earn any rewards. Instead, split the stake between two pools
     // so that the other staker has a chance to bring pool one in the next
-    // staking action but at the same time user can still earn reawards from the
+    // staking action but at the same time user can still earn rewards from the
     // active pool (half of his stake)
     const result_four = fn(300n, 1000n, [500n, 1500n], minPoolStakes)
     expect(result_four).to.eql([150n, 150n])
@@ -287,7 +297,7 @@ describe('TonPoolStaker_calculateStakeAmount', () => {
     // there is a chance to make second pool active
     //
     // strategy: user stake was used to activate one pool, the remainder can
-    // either be staked with the second pool or split in between activa/inactive
+    // either be staked with the second pool or split in between active/inactive
     // pool. In the first case user doesn't earn anything on inactive pool so in
     // below case that would 4150 (our of 10150) earning no rewards. In the
     // second case only 2075 doesn't earn rewards, but at least the portion of

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -150,7 +150,7 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
   describe('should reject invalid amounts', () => {
     it('should throw error if user wants to withdraw more than available', () => {
       expect(() => fn(21n, 10n, [20n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])).to.throw(
-        'requested withdrawal amount exceeds available user stakes'
+        'Requested amount exceeds available stakes'
       )
     })
 

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -47,13 +47,6 @@ describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
       const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [10n, 10n])
       expect(result).to.deep.equal([2n, 3n])
     })
-
-    // This optimization it's not done on the SDK yet. SDK doesn't take into account that unstake the userMaxUnstakeAbsolute can still allow the pool to be active
-    // it('should unstake userMaxUnstakeToKeepPoolActive partially and userMaxUnstakeAbsolute', () => {
-    //   const result = fn(13n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [10n, 10n])
-    //   expect(result).to.deep.equal([3n, 10n]) <---- Optimized return
-    //   expect(result).to.deep.equal([10n, 3n]) <---- Not optimized return, disables one pool when it's not necessary, SDK currently returns this
-    // })
   })
 
   describe('should disable pool with lowest balance, amount >= userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
@@ -146,7 +139,6 @@ describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
     })
   })
 
-  // TODO: implement this test case
   describe('should reject invalid amounts', () => {
     it('should throw error if user wants to withdraw more than available', () => {
       expect(() => fn(21n, 10n, [20n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])).to.throw(

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -167,10 +167,9 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
     })
   })
 
-  describe('should allow partial withdraw when pool bellow userMinStake if user has deposit and ready to withdraw amounts', () => {
+  describe('should allow partial withdraw when pool is bellow userMinStake and user has deposit and ready to withdraw amounts', () => {
     // userBalance = [6n, 6n] < userMinStake = 7n
     // userDepositingAndAvailableToWithdraw=[4n, 4n]
-    // Pools are already bellow userMinStake, so we either unstake all or partially the depositing and ready to withdraw amounts
     it('should withdraw all from one pool and the rest from depositing and ready to withdraw amounts', () => {
       const result = fn(12n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
       expect(result).to.deep.equal([10n, 2n])
@@ -178,7 +177,6 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
 
     // userBalance = [6n, 6n] < userMinStake = 7n
     // userDepositingAndAvailableToWithdraw=[4n, 4n]
-    // Pools are already bellow userMinStake, so we either unstake all or partially the depositing and ready to withdraw amounts
     it('should withdraw partially the depositing and ready to withdraw amounts', () => {
       const result = fn(7n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
       expect(result).to.deep.equal([3n, 4n])

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -25,57 +25,122 @@ describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const minStake = 10n
 
   it('should withdraw from the highest balance pool first', () => {
-    const result = fn(5n, minStake, [15n, 20n], [10n, 10n], [0n, 0n])
+    const result = fn({
+      amount: 5n,
+      minElectionStake: minStake,
+      currentPoolBalances: [15n, 20n],
+      userMaxUnstakeAmounts: [10n, 10n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([0n, 5n])
   })
 
   it('should not split withdraw to two pools if not required', () => {
-    const result = fn(10n, minStake, [20n, 20n], [10n, 10n], [0n, 0n])
+    const result = fn({
+      amount: 10n,
+      minElectionStake: minStake,
+      currentPoolBalances: [20n, 20n],
+      userMaxUnstakeAmounts: [10n, 10n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([10n, 0n])
   })
 
   it('should split withdraw to avoid pool deactivation', () => {
-    const result = fn(10n, minStake, [15n, 15n], [10n, 10n], [0n, 0n])
+    const result = fn({
+      amount: 10n,
+      minElectionStake: minStake,
+      currentPoolBalances: [15n, 15n],
+      userMaxUnstakeAmounts: [10n, 10n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([5n, 5n])
   })
 
-  it('should withdraw from multiple pools if needed', () => {
-    const result = fn(15n, minStake, [20n, 20n], [10n, 10n], [0n, 0n])
-    expect(result).to.deep.equal([10n, 5n])
-  })
-
   it('should not withdraw if user stake is zero', () => {
-    const result = fn(5n, minStake, [15n, 20n], [0n, 10n], [0n, 0n])
+    const result = fn({
+      amount: 5n,
+      minElectionStake: minStake,
+      currentPoolBalances: [15n, 20n],
+      userMaxUnstakeAmounts: [0n, 10n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([0n, 5n])
   })
 
   it('should handle exact balance matches', () => {
-    const result = fn(10n, minStake, [20n, 20n], [10n, 5n], [0n, 0n])
+    const result = fn({
+      amount: 10n,
+      minElectionStake: minStake,
+      currentPoolBalances: [20n, 20n],
+      userMaxUnstakeAmounts: [10n, 5n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([10n, 0n])
   })
 
   it('should withdraw if one pool is empty', () => {
-    let result = fn(5n, minStake, [0n, 20n], [0n, 5n], [0n, 0n])
+    let result = fn({
+      amount: 5n,
+      minElectionStake: minStake,
+      currentPoolBalances: [0n, 20n],
+      userMaxUnstakeAmounts: [0n, 5n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([0n, 5n])
 
-    result = fn(5n, minStake, [20n, 10n], [5n, 0n], [0n, 0n])
+    result = fn({
+      amount: 5n,
+      minElectionStake: minStake,
+      currentPoolBalances: [20n, 10n],
+      userMaxUnstakeAmounts: [5n, 0n],
+      userCurrentWithdrawals: [0n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([5n, 0n])
   })
 
   it('should withdraw from withdrawable amount even if the pool is empty', () => {
-    const result = fn(5n, 0n, [0n, 0n], [5n, 0n], [5n, 0n])
+    const result = fn({
+      amount: 5n,
+      minElectionStake: 0n,
+      currentPoolBalances: [0n, 0n],
+      userMaxUnstakeAmounts: [5n, 0n],
+      userCurrentWithdrawals: [5n, 0n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([5n, 0n])
   })
 
-  it('should withdraw max amount if the pool is empty', () => {
-    const result = fn(30n, 0n, [10n, 10n], [15n, 15n], [5n, 5n])
+  it('should withdraw max amount', () => {
+    const result = fn({
+      amount: 30n,
+      minElectionStake: 0n,
+      currentPoolBalances: [10n, 10n],
+      userMaxUnstakeAmounts: [15n, 15n],
+      userCurrentWithdrawals: [5n, 5n],
+      userMinStake: [0n, 0n]
+    })
     expect(result).to.deep.equal([15n, 15n])
   })
 
   it('should throw error if user wants to withdraw more than available', () => {
-    expect(() => fn(21n, 10n, [20n, 20n], [10n, 10n], [0n, 0n])).to.throw(
-      'requested withdrawal amount exceeds available user stakes'
-    )
+    expect(() =>
+      fn({
+        amount: 21n,
+        minElectionStake: 10n,
+        currentPoolBalances: [20n, 20n],
+        userMaxUnstakeAmounts: [10n, 10n],
+        userCurrentWithdrawals: [0n, 0n],
+        userMinStake: [0n, 0n]
+      })
+    ).to.throw('requested withdrawal amount exceeds available user stakes')
   })
 })
 

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -20,7 +20,6 @@ describe('TonPoolStaker_selectPool', () => {
   })
 })
 
-// Order os tries userMaxUnstakeToKeepPoolActive -> userMaxUnstakeToKeepPoolAboveMin -> userMaxUnstakeAbsolute
 describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const fn = TonPoolStaker.calculateUnstakePoolAmount
   const minElectionStake = 10n

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -20,45 +20,59 @@ describe('TonPoolStaker_selectPool', () => {
   })
 })
 
-describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
+describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
   const fn = TonPoolStaker.calculateUnstakePoolAmount
-  const minStake = 10n
+  const minElectionStake = 10n
+
+  describe('should keep both pools active', () => {
+    it('should withdraw from one pool if it has enough stake above election stake', () => {
+      const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
+      expect(result).to.deep.equal([0n, 5n])
+    })
+
+    it("should withdraw from both pools if one doesn't have enough stake above election stake", () => {
+      const result = fn(15n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
+      expect(result).to.deep.equal([5n, 10n])
+    })
+
+    it('should withdraw from both pools to follow userMinStake restriction', () => {
+      const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [7n, 7n])
+      expect(result).to.deep.equal([2n, 3n])
+    })
+  })
+
+  // ------- OLD TESTS -------
 
   it('should withdraw from the highest balance pool first', () => {
-    const result = fn(5n, minStake, [15n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
+    const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([0n, 5n])
   })
 
   it('should not split withdraw to two pools if not required', () => {
-    const result = fn(10n, minStake, [20n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
+    const result = fn(10n, minElectionStake, [20n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([10n, 0n])
   })
 
   it('should split withdraw to avoid pool deactivation', () => {
-    const result = fn(10n, minStake, [15n, 15n], [10n, 10n], [0n, 0n], [0n, 0n])
+    const result = fn(10n, minElectionStake, [15n, 15n], [10n, 10n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([5n, 5n])
   })
 
-  it('should withdraw from multiple pools if needed', () => {
-    const result = fn(15n, minStake, [20n, 20n], [10n, 10n], [0n, 0n], [0n, 0n])
-    expect(result).to.deep.equal([10n, 5n])
-  })
-
   it('should not withdraw if user stake is zero', () => {
-    const result = fn(5n, minStake, [15n, 20n], [0n, 10n], [0n, 0n], [0n, 0n])
+    const result = fn(5n, minElectionStake, [15n, 20n], [0n, 10n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([0n, 5n])
   })
 
   it('should handle exact balance matches', () => {
-    const result = fn(10n, minStake, [20n, 20n], [10n, 5n], [0n, 0n], [0n, 0n])
+    const result = fn(10n, minElectionStake, [20n, 20n], [10n, 5n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([10n, 0n])
   })
 
   it('should withdraw if one pool is empty', () => {
-    let result = fn(5n, minStake, [0n, 20n], [0n, 5n], [0n, 0n], [0n, 0n])
+    let result = fn(5n, minElectionStake, [0n, 20n], [0n, 5n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([0n, 5n])
 
-    result = fn(5n, minStake, [20n, 10n], [5n, 0n], [0n, 0n], [0n, 0n])
+    result = fn(5n, minElectionStake, [20n, 10n], [5n, 0n], [0n, 0n], [0n, 0n])
     expect(result).to.deep.equal([5n, 0n])
   })
 
@@ -67,7 +81,7 @@ describe('TonPoolStaker_calculateUnstakePoolAmount', () => {
     expect(result).to.deep.equal([5n, 0n])
   })
 
-  it('should withdraw max amount if the pool is empty', () => {
+  it('should withdraw max amount', () => {
     const result = fn(30n, 0n, [10n, 10n], [15n, 15n], [5n, 5n], [0n, 0n])
     expect(result).to.deep.equal([15n, 15n])
   })

--- a/packages/ton/test/pool-staker.spec.ts
+++ b/packages/ton/test/pool-staker.spec.ts
@@ -43,58 +43,79 @@ describe.only('TonPoolStaker_calculateUnstakePoolAmount', () => {
 
     // pool1: userMaxUnstakeToKeepPoolActive (5n) > userMaxUnstakeToKeepPoolAboveMin (3n)
     // pool2: userMaxUnstakeToKeepPoolActive (10n) > userMaxUnstakeToKeepPoolAboveMin (3n)
-    it('should unstake userMaxUnstakeToKeepPoolActive and userMaxUnstakeToKeepPoolActive, when userMaxUnstakeToKeepPoolActive > userMaxUnstakeToKeepPoolAboveMin', () => {
+    it('should unstake userMaxUnstakeToKeepPoolActive partially and userMaxUnstakeToKeepPoolAboveMin fully, when userMaxUnstakeToKeepPoolActive > userMaxUnstakeToKeepPoolAboveMin', () => {
       const result = fn(5n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [10n, 10n])
       expect(result).to.deep.equal([2n, 3n])
     })
 
     // This optimization it's not done on the SDK yet. SDK doesn't take into account that unstake the userMaxUnstakeAbsolute can still allow the pool to be active
-    // it('should withdraw from both pools to follow userMinStake restriction', () => {
+    // it('should unstake userMaxUnstakeToKeepPoolActive partially and userMaxUnstakeAbsolute', () => {
     //   const result = fn(13n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [10n, 10n])
     //   expect(result).to.deep.equal([3n, 10n]) <---- Optimized return
     //   expect(result).to.deep.equal([10n, 3n]) <---- Not optimized return, disables one pool when it's not necessary, SDK currently returns this
     // })
   })
 
-  describe('should disable pool 1, amount > userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
-    it('should unstake userMaxUnstakeToKeepPoolActive and userMaxUnstakeToKeepPoolAboveMin fully', () => {
-      const result = fn(6n, minElectionStake, [12n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
-      expect(result).to.deep.equal([2n, 4n])
+  describe('should disable pool with lowest balance, amount > userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
+    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeToKeepPoolAboveMin fully', () => {
+      const result = fn(8n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
+      expect(result).to.deep.equal([3n, 5n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolActive and userMaxUnstakeToKeepPoolAboveMin partially', () => {
-      const result = fn(5n, minElectionStake, [12n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
-      expect(result).to.deep.equal([2n, 3n])
+    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeToKeepPoolAboveMin partially', () => {
+      const result = fn(6n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
+      expect(result).to.deep.equal([3n, 3n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolActive and userMaxUnstakeAbsolute', () => {
-      const result = fn(12n, minElectionStake, [12n, 12n], [10n, 10n], [5n, 9n], [10n, 10n])
-      expect(result).to.deep.equal([2n, 10n])
+    it('should unstake userMaxUnstakeToKeepPoolActive fully and userMaxUnstakeAbsolute', () => {
+      const result = fn(13n, minElectionStake, [13n, 12n], [10n, 10n], [5n, 5n], [10n, 10n])
+      expect(result).to.deep.equal([3n, 10n])
     })
 
-    it('should unstake userMaxUnstakeToKeepPoolActive and userMaxUnstakeAbsolute, when userMaxUnstakeToKeepPoolActive > userMaxUnstakeToKeepPoolAboveMin', () => {
-      const result = fn(5n, minElectionStake, [15n, 10n], [10n, 10n], [9n, 6n], [10n, 10n])
-      expect(result).to.deep.equal([1n, 4n])
+    it('should unstake userMaxUnstakeToKeepPoolActive partially and userMaxUnstakeToKeepPoolAboveMin partially, when userMaxUnstakeToKeepPoolActive > userMaxUnstakeToKeepPoolAboveMin', () => {
+      const result = fn(7n, minElectionStake, [20n, 10n], [10n, 10n], [5n, 5n], [10n, 10n])
+      expect(result).to.deep.equal([5n, 2n])
+    })
+  })
+
+  describe('should disable pool with highest balance, amount > userMaxUnstakeToKeepPoolActive1 + userMaxUnstakeToKeepPoolActive2', () => {
+    it('should unstake userMaxUnstakeToKeepPoolAboveMin fully and userMaxUnstakeToKeepPoolActive fully', () => {
+      const result = fn(9n, minElectionStake, [13n, 12n], [10n, 5n], [3n, 3n], [10n, 5n])
+      expect(result).to.deep.equal([7n, 2n])
+    })
+
+    it('should unstake userMaxUnstakeToKeepPoolAboveMin partially and userMaxUnstakeToKeepPoolActive fully', () => {
+      const result = fn(8n, minElectionStake, [13n, 12n], [10n, 4n], [1n, 1n], [10n, 4n])
+      expect(result).to.deep.equal([6n, 2n])
+    })
+
+    it('should unstake userMaxUnstakeAbsolute and userMaxUnstakeToKeepPoolActive fully', () => {
+      const result = fn(12n, minElectionStake, [13n, 12n], [10n, 4n], [1n, 1n], [10n, 4n])
+      expect(result).to.deep.equal([10n, 2n])
     })
   })
 
   // TODO: implement this test case
+  // describe('should disable both pools', () => {})
+  // describe('should unstake all', () => {})
   // describe('should reject invalid amounts', () => {})
 
-  // userBalance = [6n, 6n] < userMinStake = 7n
-  // userDepositingAndAvailableToWithdraw=[4n, 4n]
-  // Pools are already bellow userMinStake, so we either unstake all or partially the depositing and ready to withdraw amounts
-  it('should withdraw all from one pool and the rest from depositing and ready to withdraw amounts', () => {
-    const result = fn(12n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
-    expect(result).to.deep.equal([10n, 2n])
-  })
+  describe('should allow partial withdraw when pool bellow userMinStake if user has deposit and ready to withdraw amounts', () => {
+    // userBalance = [6n, 6n] < userMinStake = 7n
+    // userDepositingAndAvailableToWithdraw=[4n, 4n]
+    // Pools are already bellow userMinStake, so we either unstake all or partially the depositing and ready to withdraw amounts
+    it('should withdraw all from one pool and the rest from depositing and ready to withdraw amounts', () => {
+      const result = fn(12n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
+      expect(result).to.deep.equal([10n, 2n])
+    })
 
-  // userBalance = [6n, 6n] < userMinStake = 7n
-  // userDepositingAndAvailableToWithdraw=[4n, 4n]
-  // Pools are already bellow userMinStake, so we either unstake all or partially the depositing and ready to withdraw amounts
-  it('should withdraw partially the depositing and ready to withdraw amounts', () => {
-    const result = fn(7n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
-    expect(result).to.deep.equal([3n, 4n])
+    // userBalance = [6n, 6n] < userMinStake = 7n
+    // userDepositingAndAvailableToWithdraw=[4n, 4n]
+    // Pools are already bellow userMinStake, so we either unstake all or partially the depositing and ready to withdraw amounts
+    it('should withdraw partially the depositing and ready to withdraw amounts', () => {
+      const result = fn(7n, minElectionStake, [15n, 20n], [10n, 10n], [7n, 7n], [6n, 6n])
+      expect(result).to.deep.equal([3n, 4n])
+    })
   })
 
   // ------- OLD TESTS -------


### PR DESCRIPTION
Before: 

- SDK didn't allow withdraw from pools bellow minElectionStake
- SDK didn't take into account minUserStake per pool

This changes fixes the two issues above and introduce more test cases for TON and 5 fallback strategies for unstaking prioritizing pool liveness: 

## Try to withdraw from the best pairs first, do the permutation of: userMaxUnstakeToKeepPoolActive, userMaxUnstakeToKeepPoolAboveMin, userMaxUnstakeAbsolute

- Best scenario keep both pools active
  - userMaxUnstakeToKeepPoolActive1, userMaxUnstakeToKeepPoolActive2
- Keep pool 1 active
  - userMaxUnstakeToKeepPoolActive1, userMaxUnstakeAbsolute2
  - userMaxUnstakeToKeepPoolActive1, userMaxUnstakeToKeepAboveMin2
- Keep pool 2 active
  - userMaxUnstakeToKeepPoolActive2, userMaxUnstakeToKeepAboveMin1
  - userMaxUnstakeToKeepPoolActive2, userMaxUnstakeAbsolute1
- Deactivate both pools
  - userMaxUnstakeToKeepAboveMin1, userMaxUnstakeToKeepAboveMin2
  - userMaxUnstakeAbsolute1, userMaxUnstakeAbsolute2