### PR TITLE
Ethereum fix rewards data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8974,7 +8974,7 @@
     },
     "packages/cosmos": {
       "name": "@chorus-one/cosmos",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",
@@ -8992,7 +8992,7 @@
     },
     "packages/ethereum": {
       "name": "@chorus-one/ethereum",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/ethereum",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "All-in-one toolkit for building staking dApps on Ethereum network",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json",

--- a/packages/ethereum/src/lib/methods/getRewardsHistory.ts
+++ b/packages/ethereum/src/lib/methods/getRewardsHistory.ts
@@ -9,13 +9,20 @@ export async function getRewardsHistory (params: {
   userAccount: Hex
 }) {
   const { connector, from, to, vault, userAccount } = params
+
+  const MAX_DAYS = 1000 // 1000 days is the maximum limit for the query
+  const daysDiff = Math.floor((to - from) / (1000 * 60 * 60 * 24))
+  if (daysDiff > MAX_DAYS) {
+    throw new Error(`Time range cannot exceed ${MAX_DAYS} days`)
+  }
+
   const rewardsData = await connector.graphqlRequest({
     type: 'graph',
     op: 'UserRewards',
     query:
       'query UserRewards( $where: AllocatorStats_filter $limit: Int) { allocator: allocatorStats_collection( interval: day first: $limit where: $where orderBy: timestamp orderDirection: asc ) { apy timestamp earnedAssets totalAssets }}',
     variables: {
-      limit: 1000, // 1000 is the maximum limit for the query
+      limit: MAX_DAYS,
       where: {
         allocator_: {
           address: userAccount.toLowerCase(),

--- a/packages/ethereum/test/getRewardsHistory.spec.ts
+++ b/packages/ethereum/test/getRewardsHistory.spec.ts
@@ -75,4 +75,23 @@ describe('EthereumStaker.getRewards', () => {
       }
     ])
   })
+
+  it('throws error when time range exceeds 1000 days', async function () {
+    disableHoodi.bind(this)()
+
+    const startTime = 1640995200000 // 2022-01-01
+    const endTime = startTime + 1001 * 24 * 60 * 60 * 1000 // 1001 days later
+
+    try {
+      await staker.getRewardsHistory({
+        startTime,
+        endTime,
+        validatorAddress,
+        delegatorAddress
+      })
+      assert.fail('Should have thrown an error')
+    } catch (error) {
+      assert.equal(error.message, 'Time range cannot exceed 1000 days')
+    }
+  })
 })

--- a/packages/ethereum/test/getRewardsHistory.spec.ts
+++ b/packages/ethereum/test/getRewardsHistory.spec.ts
@@ -11,10 +11,9 @@ describe('EthereumStaker.getRewards', () => {
 
   beforeEach(async () => {
     const setup = await prepareTests()
-    // Use Stakewise Pool for testing, it has more interesting data on rewards
-    validatorAddress = '0xac0f906e433d58fa868f936e8a43230473652885'
-    // Use one of the first delegators to the Stakewise Pool
-    delegatorAddress = '0x387a4700117D6fe815d71146db984880EC423884'
+    validatorAddress = setup.validatorAddress
+    // Use one of the first delegators to the MevMax Vault
+    delegatorAddress = '0xA3FBae7A9834862A5853D39d850aBcBCE5a1AFdA'
     staker = setup.staker
   })
 
@@ -23,203 +22,56 @@ describe('EthereumStaker.getRewards', () => {
 
     const rewards = await staker.getRewardsHistory({
       startTime: 1735689600000, // 2025-01-01
-      endTime: 1738368000000, // 2025-02-01
+      endTime: 1736294400000, // 2025-01-08 - one week
       validatorAddress,
       delegatorAddress
     })
 
+    // 7 days, end day is not included: [from, to)
+    assert.equal(rewards.length, 7)
+
     assert.deepEqual(rewards, [
       {
         timestamp: 1735689600000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
+        amount: '0.008753377787080096',
+        totalRewards: '0.008753377787080096',
+        dailyRewards: '0.000022443428921008'
       },
       {
         timestamp: 1735776000000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
+        amount: '0.008774544232426604',
+        totalRewards: '0.008774544232426604',
+        dailyRewards: '0.000021166445346508'
       },
       {
         timestamp: 1735862400000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
+        amount: '0.008792737294644708',
+        totalRewards: '0.008792737294644708',
+        dailyRewards: '0.000018193062218104'
       },
       {
         timestamp: 1735948800000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
+        amount: '0.00880915741497382',
+        totalRewards: '0.00880915741497382',
+        dailyRewards: '0.000016420120329112'
       },
       {
         timestamp: 1736035200000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
+        amount: '0.008826192471555911',
+        totalRewards: '0.008826192471555911',
+        dailyRewards: '0.000017035056582091'
       },
       {
         timestamp: 1736121600000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
+        amount: '0.008848166217191916',
+        totalRewards: '0.008848166217191916',
+        dailyRewards: '0.000021973745636005'
       },
       {
         timestamp: 1736208000000,
-        amount: '0.000000000000000001',
-        totalRewards: '0.000000000000000001',
-        dailyRewards: '0'
-      },
-      {
-        timestamp: 1736294400000,
-        amount: '4.500180294719893715',
-        totalRewards: '4.500180294719893715',
-        dailyRewards: '0.000180294719893714'
-      },
-      {
-        timestamp: 1736380800000,
-        amount: '4.500343838739714004',
-        totalRewards: '4.500343838739714004',
-        dailyRewards: '0.000163544019820289'
-      },
-      {
-        timestamp: 1736467200000,
-        amount: '4.500724597414951508',
-        totalRewards: '4.500724597414951508',
-        dailyRewards: '0.000380758675237504'
-      },
-      {
-        timestamp: 1736553600000,
-        amount: '4.501051734402490899',
-        totalRewards: '4.501051734402490899',
-        dailyRewards: '0.000327136987539391'
-      },
-      {
-        timestamp: 1736640000000,
-        amount: '4.501408897854618204',
-        totalRewards: '4.501408897854618204',
-        dailyRewards: '0.000357163452127305'
-      },
-      {
-        timestamp: 1736726400000,
-        amount: '4.501755244384521194',
-        totalRewards: '4.501755244384521194',
-        dailyRewards: '0.00034634652990299'
-      },
-      {
-        timestamp: 1736812800000,
-        amount: '4.502104714425675114',
-        totalRewards: '4.502104714425675114',
-        dailyRewards: '0.00034947004115392'
-      },
-      {
-        timestamp: 1736899200000,
-        amount: '4.502478354511437552',
-        totalRewards: '4.502478354511437552',
-        dailyRewards: '0.000373640085762438'
-      },
-      {
-        timestamp: 1736985600000,
-        amount: '4.502824687684210262',
-        totalRewards: '4.502824687684210262',
-        dailyRewards: '0.00034633317277271'
-      },
-      {
-        timestamp: 1737072000000,
-        amount: '4.503175621268643342',
-        totalRewards: '4.503175621268643342',
-        dailyRewards: '0.00035093358443308'
-      },
-      {
-        timestamp: 1737158400000,
-        amount: '4.503541935799732674',
-        totalRewards: '4.503541935799732674',
-        dailyRewards: '0.000366314531089332'
-      },
-      {
-        timestamp: 1737244800000,
-        amount: '4.503929381136803542',
-        totalRewards: '4.503929381136803542',
-        dailyRewards: '0.000387445337070868'
-      },
-      {
-        timestamp: 1737331200000,
-        amount: '4.504583908315077103',
-        totalRewards: '4.504583908315077103',
-        dailyRewards: '0.000654527178273561'
-      },
-      {
-        timestamp: 1737417600000,
-        amount: '5.505398562004289498',
-        totalRewards: '5.505398562004289498',
-        dailyRewards: '0.000791296462689308'
-      },
-      {
-        timestamp: 1737504000000,
-        amount: '5.508996433773194235',
-        totalRewards: '5.508996433773194235',
-        dailyRewards: '0.003621231618800895'
-      },
-      {
-        timestamp: 1737590400000,
-        amount: '5.509649562709147252',
-        totalRewards: '5.509649562709147252',
-        dailyRewards: '0.000653137011885009'
-      },
-      {
-        timestamp: 1737676800000,
-        amount: '5.511344373510842162',
-        totalRewards: '5.511344373510842162',
-        dailyRewards: '0.001694825980314944'
-      },
-      {
-        timestamp: 1737763200000,
-        amount: '5.511913182049208305',
-        totalRewards: '5.511913182049208305',
-        dailyRewards: '0.000568804185377588'
-      },
-      {
-        timestamp: 1737849600000,
-        amount: '5.512171842756760304',
-        totalRewards: '5.512171842756760304',
-        dailyRewards: '0.000258661777777363'
-      },
-      {
-        timestamp: 1737936000000,
-        amount: '5.512828622519735305',
-        totalRewards: '5.512828622519735305',
-        dailyRewards: '0.000656787793936647'
-      },
-      {
-        timestamp: 1738022400000,
-        amount: '5.513298075564695477',
-        totalRewards: '5.513298075564695477',
-        dailyRewards: '0.000469462235155532'
-      },
-      {
-        timestamp: 1738108800000,
-        amount: '5.513192394302233519',
-        totalRewards: '5.513192394302233519',
-        dailyRewards: '-0.000105684535506714'
-      },
-      {
-        timestamp: 1738195200000,
-        amount: '5.513426225627519923',
-        totalRewards: '5.513426225627519923',
-        dailyRewards: '0.000233837944457476'
-      },
-      {
-        timestamp: 1738281600000,
-        amount: '5.513568486790528493',
-        totalRewards: '5.513568486790528493',
-        dailyRewards: '0.000142268482502555'
-      },
-      {
-        timestamp: 1738368000000,
-        amount: '5.513756274302327208',
-        totalRewards: '5.513756274302327208',
-        dailyRewards: '0.000187792191345239'
+        amount: '0.008866858175311622',
+        totalRewards: '0.008866858175311622',
+        dailyRewards: '0.000018691958119706'
       }
     ])
   })


### PR DESCRIPTION
The cumulative rewards data was wrong; stakewise api does not return cumulative data anymore.

Current approach: we fetch all entries since vault creation - ~600 days for the first stakewise vault, 565 days for mev max vault. Then we calculate the cumulative total from daily rewards.

There is a caveat, api only allows to fetch up to 1000 days. Which means in 400 days, it would throw an error.