### PR TITLE
Make TON requests sequential instead of parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8974,7 +8974,7 @@
     },
     "packages/cosmos": {
       "name": "@chorus-one/cosmos",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",
@@ -9236,7 +9236,7 @@
     },
     "packages/ton": {
       "name": "@chorus-one/ton",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/ton",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "All-in-one tooling for building staking dApps on TON",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json"

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -90,9 +90,11 @@ export class TonPoolStaker extends TonBaseStaker {
       validatorAddresses
     )
 
-    const poolParams = await Promise.all(
-      validatorAddresses.map((validatorAddress) => this.getPoolParamsUnformatted({ validatorAddress }))
-    )
+    const poolParams: Awaited<ReturnType<TonPoolStaker['getPoolParamsUnformatted']>>[] = []
+    for (const validatorAddress of validatorAddresses) {
+      const params = await this.getPoolParamsUnformatted({ validatorAddress })
+      poolParams.push(params)
+    }
 
     const lowestMinStake: bigint = poolParams
       .filter((param) => param.minStake !== 0n)
@@ -217,9 +219,11 @@ export class TonPoolStaker extends TonBaseStaker {
       }
     }
 
-    const poolParamsData = await Promise.all(
-      validatorAddresses.map((validatorAddress) => this.getPoolParamsUnformatted({ validatorAddress }))
-    )
+    const poolParamsData: Awaited<ReturnType<TonPoolStaker['getPoolParamsUnformatted']>>[] = []
+    for (const validatorAddress of validatorAddresses) {
+      const data = await this.getPoolParamsUnformatted({ validatorAddress })
+      poolParamsData.push(data)
+    }
 
     const msgs: Message[] = []
 
@@ -373,11 +377,19 @@ export class TonPoolStaker extends TonBaseStaker {
 
   /** @ignore */
   private async getPoolDataForDelegator (delegatorAddress: string, validatorAddresses: string[]) {
-    const [poolStatus, userStake, minElectionStake] = await Promise.all([
-      Promise.all(validatorAddresses.map((validatorAddress) => this.getPoolStatus(validatorAddress))),
-      Promise.all(validatorAddresses.map((validatorAddress) => this.getStake({ delegatorAddress, validatorAddress }))),
-      this.getElectionMinStake()
-    ])
+    const poolStatus: Awaited<ReturnType<TonPoolStaker['getPoolStatus']>>[] = []
+    for (const validatorAddress of validatorAddresses) {
+      const status = await this.getPoolStatus(validatorAddress)
+      poolStatus.push(status)
+    }
+
+    const userStake: Awaited<ReturnType<TonPoolStaker['getStake']>>[] = []
+    for (const validatorAddress of validatorAddresses) {
+      const stake = await this.getStake({ delegatorAddress, validatorAddress })
+      userStake.push(stake)
+    }
+
+    const minElectionStake: Awaited<ReturnType<TonPoolStaker['getElectionMinStake']>> = await this.getElectionMinStake()
 
     const currentPoolBalances: [bigint, bigint] =
       validatorAddresses.length === 2 ? [poolStatus[0].balance, poolStatus[1].balance] : [poolStatus[0].balance, 0n]


### PR DESCRIPTION
Currently the TON RPC requests are made all in parallel leading to hit the RPC limit (even on RPC paid plans). 

This PR make them sequential to avoid this issue