### PR TITLE
Include default referrer on sdk tx

### DIFF
--- a/packages/cosmos/src/staker.ts
+++ b/packages/cosmos/src/staker.ts
@@ -21,6 +21,7 @@ import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { Coin } from 'cosmjs-types/cosmos/base/v1beta1/coin'
 import { newCosmosClient, CosmosClient } from './client'
 import BigNumber from 'bignumber.js'
+import { DEFAULT_TRACKING_REF_CODE } from '@chorus-one/utils'
 
 /**
  * This class provides the functionality to stake, unstake, redelegate, and withdraw rewards for Cosmos-based blockchains.
@@ -364,20 +365,12 @@ export class CosmosStaker {
     const cosmosClient = this.getClient()
     const chainID = this.getChainID()
 
-    const { signer, signerAddress, tx, memo } = params
+    const { signer, signerAddress, tx, memo = DEFAULT_TRACKING_REF_CODE } = params
 
     const gas = await getGas(cosmosClient, this.networkConfig, signerAddress, signer, tx, memo)
 
     const acc = await getAccount(cosmosClient, this.networkConfig.lcdUrl, signerAddress)
-    const signDoc = await genSignableTx(
-      this.networkConfig,
-      chainID,
-      tx,
-      acc.accountNumber,
-      acc.sequence,
-      gas,
-      memo ?? ''
-    )
+    const signDoc = await genSignableTx(this.networkConfig, chainID, tx, acc.accountNumber, acc.sequence, gas, memo)
 
     const isEVM = this.networkConfig.isEVM ?? false
     const { sig, pk } = await genSignDocSignature(signer, acc, signDoc, isEVM)

--- a/packages/ethereum/src/constants.ts
+++ b/packages/ethereum/src/constants.ts
@@ -32,10 +32,3 @@ export const CHORUS_ONE_ETHEREUM_VALIDATORS = {
     obolDvVault: '0x2148ffbc0a2d83f5e3605041f5b85d54305f803c'
   }
 } as const
-
-// TODO: Check which address we should use here with Dmitry, or derive it from DEFAULT_TRACKING_REF_CODE
-/**
- * Default tracking address for SDK-originated transactions.
- * This address is used as the default referrer when no specific referrer is provided.
- */
-export const DEFAULT_SDK_TRACKING_ADDRESS = '0x742d35Cc6634C0532925a3b8D40Ec0A1c4cF4000' as const

--- a/packages/ethereum/src/constants.ts
+++ b/packages/ethereum/src/constants.ts
@@ -32,3 +32,10 @@ export const CHORUS_ONE_ETHEREUM_VALIDATORS = {
     obolDvVault: '0x2148ffbc0a2d83f5e3605041f5b85d54305f803c'
   }
 } as const
+
+// TODO: Check which address we should use here with Dmitry, or derive it from DEFAULT_TRACKING_REF_CODE
+/**
+ * Default tracking address for SDK-originated transactions.
+ * This address is used as the default referrer when no specific referrer is provided.
+ */
+export const DEFAULT_SDK_TRACKING_ADDRESS = '0x742d35Cc6634C0532925a3b8D40Ec0A1c4cF4000' as const

--- a/packages/ethereum/src/lib/methods/buildMintTx.ts
+++ b/packages/ethereum/src/lib/methods/buildMintTx.ts
@@ -1,7 +1,8 @@
-import { Hex, encodeFunctionData, zeroAddress } from 'viem'
+import { Hex, encodeFunctionData } from 'viem'
 import { StakewiseConnector } from '../connector'
 import { Transaction } from '../types/transaction'
 import { VaultABI } from '../contracts/vaultAbi'
+import { DEFAULT_SDK_TRACKING_ADDRESS } from '../../constants'
 
 export const buildMintTx = async (request: {
   connector: StakewiseConnector
@@ -10,7 +11,7 @@ export const buildMintTx = async (request: {
   amount: bigint
   referrer?: Hex
 }): Promise<Transaction> => {
-  const { userAccount, amount, vault, referrer = zeroAddress } = request
+  const { userAccount, amount, vault, referrer = DEFAULT_SDK_TRACKING_ADDRESS } = request
 
   const tx: Hex = encodeFunctionData({
     abi: VaultABI,

--- a/packages/ethereum/src/lib/methods/buildMintTx.ts
+++ b/packages/ethereum/src/lib/methods/buildMintTx.ts
@@ -2,7 +2,7 @@ import { Hex, encodeFunctionData } from 'viem'
 import { StakewiseConnector } from '../connector'
 import { Transaction } from '../types/transaction'
 import { VaultABI } from '../contracts/vaultAbi'
-import { DEFAULT_SDK_TRACKING_ADDRESS } from '../../constants'
+import { getDefaultTrackingAddress } from '../utils/getDefaultTrackingAddress'
 
 export const buildMintTx = async (request: {
   connector: StakewiseConnector
@@ -11,6 +11,7 @@ export const buildMintTx = async (request: {
   amount: bigint
   referrer?: Hex
 }): Promise<Transaction> => {
+  const DEFAULT_SDK_TRACKING_ADDRESS = getDefaultTrackingAddress()
   const { userAccount, amount, vault, referrer = DEFAULT_SDK_TRACKING_ADDRESS } = request
 
   const tx: Hex = encodeFunctionData({

--- a/packages/ethereum/src/lib/methods/buildStakeTx.ts
+++ b/packages/ethereum/src/lib/methods/buildStakeTx.ts
@@ -1,9 +1,10 @@
-import { Hex, encodeFunctionData, zeroAddress } from 'viem'
+import { Hex, encodeFunctionData } from 'viem'
 import { VaultABI } from '../contracts/vaultAbi'
 import { StakewiseConnector } from '../connector'
 import { keeperABI } from '../contracts/keeperAbi'
 import { getHarvestParams } from '../utils/getHarvestParams'
 import { Transaction } from '../types/transaction'
+import { DEFAULT_SDK_TRACKING_ADDRESS } from '../../constants'
 
 export async function buildStakeTx (request: {
   connector: StakewiseConnector
@@ -12,7 +13,7 @@ export async function buildStakeTx (request: {
   amount: bigint
   referrer?: Hex
 }): Promise<Transaction> {
-  const { userAccount, connector, vault, amount, referrer = zeroAddress } = request
+  const { userAccount, connector, vault, amount, referrer = DEFAULT_SDK_TRACKING_ADDRESS } = request
   const canHarvest = await connector.eth.readContract({
     abi: keeperABI,
     address: connector.keeper,

--- a/packages/ethereum/src/lib/methods/buildStakeTx.ts
+++ b/packages/ethereum/src/lib/methods/buildStakeTx.ts
@@ -6,7 +6,7 @@ import { getHarvestParams } from '../utils/getHarvestParams'
 import { Transaction } from '../types/transaction'
 import { getDefaultTrackingAddress } from '../utils/getDefaultTrackingAddress'
 
-export async function buildStakeTx(request: {
+export async function buildStakeTx (request: {
   connector: StakewiseConnector
   userAccount: Hex
   vault: Hex

--- a/packages/ethereum/src/lib/methods/buildStakeTx.ts
+++ b/packages/ethereum/src/lib/methods/buildStakeTx.ts
@@ -4,15 +4,16 @@ import { StakewiseConnector } from '../connector'
 import { keeperABI } from '../contracts/keeperAbi'
 import { getHarvestParams } from '../utils/getHarvestParams'
 import { Transaction } from '../types/transaction'
-import { DEFAULT_SDK_TRACKING_ADDRESS } from '../../constants'
+import { getDefaultTrackingAddress } from '../utils/getDefaultTrackingAddress'
 
-export async function buildStakeTx (request: {
+export async function buildStakeTx(request: {
   connector: StakewiseConnector
   userAccount: Hex
   vault: Hex
   amount: bigint
   referrer?: Hex
 }): Promise<Transaction> {
+  const DEFAULT_SDK_TRACKING_ADDRESS = getDefaultTrackingAddress()
   const { userAccount, connector, vault, amount, referrer = DEFAULT_SDK_TRACKING_ADDRESS } = request
   const canHarvest = await connector.eth.readContract({
     abi: keeperABI,

--- a/packages/ethereum/src/lib/utils/getDefaultTrackingAddress.ts
+++ b/packages/ethereum/src/lib/utils/getDefaultTrackingAddress.ts
@@ -1,0 +1,6 @@
+import { Hex, keccak256, toHex } from 'viem'
+import { DEFAULT_TRACKING_REF_CODE } from '@chorus-one/utils'
+
+export const getDefaultTrackingAddress = (): Hex => {
+  return `0x${keccak256(toHex(DEFAULT_TRACKING_REF_CODE)).slice(-40)}` as Hex
+}

--- a/packages/solana/src/tx.ts
+++ b/packages/solana/src/tx.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { checkMaxDecimalPlaces } from '@chorus-one/utils'
-import { LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { LAMPORTS_PER_SOL, PublicKey, TransactionInstruction } from '@solana/web3.js'
 
 export function macroToDenomAmount (
   amount: string, // in macro denom (e.g. ATOM)
@@ -55,4 +55,21 @@ export function getDenomMultiplier (denomMultiplier?: string): string {
     return denomMultiplier
   }
   return BigNumber(LAMPORTS_PER_SOL).toString(10)
+}
+
+const MEMO_PROGRAM_ID: PublicKey = new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr')
+
+export function createMemoInstruction (memo: string, signerPubkeys?: Array<PublicKey>): TransactionInstruction {
+  const keys =
+    signerPubkeys == null
+      ? []
+      : signerPubkeys.map(function (key) {
+          return { pubkey: key, isSigner: true, isWritable: false }
+        })
+
+  return new TransactionInstruction({
+    keys,
+    programId: MEMO_PROGRAM_ID,
+    data: Buffer.from(memo, 'utf8')
+  })
 }

--- a/packages/ton/src/TonPoolStaker.ts
+++ b/packages/ton/src/TonPoolStaker.ts
@@ -13,6 +13,7 @@ import {
 import { defaultValidUntil, getDefaultGas, getRandomQueryId, TonBaseStaker } from './TonBaseStaker'
 import { UnsignedTx, Election, FrozenSet, PoolStatus, Message, TonTxStatus } from './types'
 import { minBigInt } from './utils'
+import { DEFAULT_TRACKING_REF_CODE } from '@chorus-one/utils'
 
 export class TonPoolStaker extends TonBaseStaker {
   /**
@@ -42,7 +43,14 @@ export class TonPoolStaker extends TonBaseStaker {
     referrer?: string
     validUntil?: number
   }): Promise<{ tx: UnsignedTx }> {
-    const { validatorAddressPair, delegatorAddress, amount, preferredStrategy, validUntil, referrer } = params
+    const {
+      validatorAddressPair,
+      delegatorAddress,
+      amount,
+      preferredStrategy,
+      validUntil,
+      referrer = DEFAULT_TRACKING_REF_CODE
+    } = params
 
     // allow staking to both pools
     const validatorAddresses = validatorAddressPair.filter((address) => address.length > 0)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -48,3 +48,5 @@ export function sortObjectByKeys<T> (obj: T): T {
   }
   return obj
 }
+
+export const DEFAULT_TRACKING_REF_CODE = 'chorusone-staking' as const

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -49,4 +49,4 @@ export function sortObjectByKeys<T> (obj: T): T {
   return obj
 }
 
-export const DEFAULT_TRACKING_REF_CODE = 'chorusone-staking' as const
+export const DEFAULT_TRACKING_REF_CODE = 'sdk-chorusone-staking' as const


### PR DESCRIPTION
Include default referrer on sdk tx for SOL, ETH, TON, Cosmos

Testing: 

- Solana: https://explorer.solana.com/tx/4uj161oMZCEafonmB2H5J233cBTA5935Mqxa8cJKpU3r6iwWjeEFcxih1R9YEfAJFtoZoKns24jWqcuUB2HnVmFz?cluster=devnet
- TON: https://testnet.tonviewer.com/transaction/3d7cbadef54e0dffb093e11c86fbbea21cc05c7658d87bc85e0c7f0bb35a299e
- Cosmos: https://explorer.mantrachain.io/MANTRA-Dukong/tx/DD2FCEDFD75F1FDBA37AB3564AC224168C7492F3CBD7DC347A57C259740F14D9
- Ethereum: https://hoodi.etherscan.io/tx/0x9c3c9fc0c14e5425d25094390b14bf38625a9137d0219139f1d68a44c01e38e0