### PR TITLE
Update Polygon testnet validator address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10172,7 +10172,7 @@
     },
     "packages/polygon": {
       "name": "@chorus-one/polygon",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",

--- a/packages/polygon/README.md
+++ b/packages/polygon/README.md
@@ -216,7 +216,7 @@ console.log(status) // 'success', 'failure', or 'unknown'
 
 ## Key Features
 
-- **Ethereum L1 Based**: Polygon PoS staking operates via ValidatorShare contracts deployed on Ethereum mainnet (or Sepolia for testnet)
+- **Ethereum L1 Based**: Polygon PoS staking operates via ValidatorShare contracts deployed on Ethereum mainnet (or Sepolia for testnet). Every transaction includes a `chainId` field so you know exactly which chain to broadcast on (`1` for mainnet, `11155111` for Sepolia).
 - **POL Token Staking**: Stake the native POL token (formerly MATIC) to validators
 - **Human-Readable Amounts**: Pass token amounts as strings (e.g., '1.5'), conversion to wei is handled automatically
 - **Slippage Protection**: Stake and unstake operations require either `slippageBps` (basis points) for automatic slippage calculation, or manual `minSharesToMint`/`maximumSharesToBurn` parameters. Exactly one must be provided — there is no default.
@@ -231,6 +231,19 @@ console.log(status) // 'success', 'failure', or 'unknown'
 - **Referrer Tracking**: Transaction builders that support referrer tracking (stake, unstake, claim rewards, compound) append a tracking marker to the transaction calldata. By default, `sdk-chorusone-staking` is used as the referrer. You can provide a custom referrer via the `referrer` parameter.
 - **Exchange Rate**: The exchange rate between shares and POL may fluctuate. Use `slippageBps` for automatic slippage protection, or specify `minSharesToMint`/`maximumSharesToBurn` directly. Foundation validators (ID < 8) use different precision than others.
 - **Validator Share Contracts**: Each validator has their own ValidatorShare contract address. You must specify the correct contract address for the validator you want to delegate to.
+- **Testnet Validators**: Testnet validators on Sepolia may be locked or inactive. To list all active ValidatorShare addresses, use [Foundry's](https://book.getfoundry.sh/) `cast`:
+
+  ```bash
+  export ETH_RPC_URL="https://ethereum-sepolia-rpc.publicnode.com"
+  SM="0x4AE8f648B1Ec892B6cc68C89cc088583964d08bE"
+  count=$(cast call $SM "NFTCounter()(uint256)")
+  for id in $(seq 1 $((count - 1))); do
+    raw=$(cast call $SM "validators(uint256)(uint256,uint256,uint256,uint256,uint256,address,address,uint8,uint256,uint256,uint256,uint256,uint256)" $id 2>/dev/null)
+    contract=$(echo "$raw" | sed -n 7p)
+    st=$(echo "$raw" | sed -n 8p)
+    [ "$st" = "1" ] && echo $contract
+  done
+  ```
 
 ## License
 

--- a/packages/polygon/package.json
+++ b/packages/polygon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/polygon",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "All-in-one toolkit for building staking dApps on Polygon network",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json",

--- a/packages/polygon/src/constants.ts
+++ b/packages/polygon/src/constants.ts
@@ -22,7 +22,9 @@ export const NETWORK_CONTRACTS: Record<PolygonNetworks, NetworkContracts> = {
 
 /** Chorus One Polygon ValidatorShare contract addresses */
 // Reference mainnet: https://staking.polygon.technology/validators/106
-// Reference testnet (Random Validator): https://staking.polygon.technology/validators/31
+// Reference testnet: https://staking.polygon.technology/validators/31
+// Note: Testnet validators may be locked. To list active validators, query the StakeManager
+// contract on Sepolia: https://sepolia.etherscan.io/address/0x4AE8f648B1Ec892B6cc68C89cc088583964d08bE
 export const CHORUS_ONE_POLYGON_VALIDATORS = {
   mainnet: '0xD9E6987D77bf2c6d0647b8181fd68A259f838C36' as Address,
   testnet: '0xe50f5ad9b885675fd11d8204eb01c83a8a32a91d' as Address
@@ -147,5 +149,33 @@ export const STAKE_MANAGER_ABI = [
     inputs: [],
     outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
     stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'validators',
+    inputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      { name: 'amount', type: 'uint256' },
+      { name: 'reward', type: 'uint256' },
+      { name: 'activationEpoch', type: 'uint256' },
+      { name: 'deactivationEpoch', type: 'uint256' },
+      { name: 'jailTime', type: 'uint256' },
+      { name: 'signer', type: 'address' },
+      { name: 'contractAddress', type: 'address' },
+      { name: 'status', type: 'uint256' },
+      { name: 'commissionRate', type: 'uint256' },
+      { name: 'lastCommissionUpdate', type: 'uint256' },
+      { name: 'delegatorsReward', type: 'uint256' },
+      { name: 'delegatedAmount', type: 'uint256' },
+      { name: 'initialRewardPerStake', type: 'uint256' }
+    ],
+    stateMutability: 'view'
   }
 ] as const
+
+export const VALIDATOR_STATUS = {
+  0: 'Inactive',
+  1: 'Active',
+  2: 'Locked',
+  3: 'Unstaked'
+} as const

--- a/packages/polygon/src/constants.ts
+++ b/packages/polygon/src/constants.ts
@@ -25,7 +25,7 @@ export const NETWORK_CONTRACTS: Record<PolygonNetworks, NetworkContracts> = {
 // Reference testnet (Random Validator): https://staking.polygon.technology/validators/31
 export const CHORUS_ONE_POLYGON_VALIDATORS = {
   mainnet: '0xD9E6987D77bf2c6d0647b8181fd68A259f838C36' as Address,
-  testnet: '0x91344055cb0511b3aa36c561d741ee356b95f1c9' as Address
+  testnet: '0xe50f5ad9b885675fd11d8204eb01c83a8a32a91d' as Address
 } as const
 
 // Reference: https://github.com/0xPolygon/pos-contracts/blob/main/contracts/staking/validatorShare/ValidatorShare.sol

--- a/packages/polygon/src/staker.ts
+++ b/packages/polygon/src/staker.ts
@@ -26,6 +26,7 @@ import {
   NETWORK_CONTRACTS,
   EXCHANGE_RATE_PRECISION,
   EXCHANGE_RATE_HIGH_PRECISION,
+  VALIDATOR_STATUS,
   type PolygonNetworks,
   type NetworkContracts
 } from './constants'
@@ -130,7 +131,8 @@ export class PolygonStaker {
       tx: {
         to: this.contracts.stakingTokenAddress,
         data,
-        value: 0n
+        value: 0n,
+        chainId: this.chain.id
       }
     }
   }
@@ -174,7 +176,10 @@ export class PolygonStaker {
 
     const amountWei = this.parseAmount(amount)
 
-    const allowance = await this.getAllowance(delegatorAddress)
+    const [allowance] = await Promise.all([
+      this.getAllowance(delegatorAddress),
+      this.assertValidatorActive(validatorShareAddress)
+    ])
     if (parseEther(allowance) < amountWei) {
       throw new Error(
         `Insufficient POL allowance. Current: ${allowance}, Required: ${amount}. Call buildApproveTx() first.`
@@ -204,7 +209,8 @@ export class PolygonStaker {
       tx: {
         to: validatorShareAddress,
         data: appendReferrerTracking(calldata, referrer),
-        value: 0n
+        value: 0n,
+        chainId: this.chain.id
       }
     }
   }
@@ -273,7 +279,8 @@ export class PolygonStaker {
       tx: {
         to: validatorShareAddress,
         data: appendReferrerTracking(calldata, referrer),
-        value: 0n
+        value: 0n,
+        chainId: this.chain.id
       }
     }
   }
@@ -331,7 +338,8 @@ export class PolygonStaker {
       tx: {
         to: validatorShareAddress,
         data,
-        value: 0n
+        value: 0n,
+        chainId: this.chain.id
       }
     }
   }
@@ -376,7 +384,8 @@ export class PolygonStaker {
       tx: {
         to: validatorShareAddress,
         data: appendReferrerTracking(calldata, referrer),
-        value: 0n
+        value: 0n,
+        chainId: this.chain.id
       }
     }
   }
@@ -407,7 +416,10 @@ export class PolygonStaker {
       throw new Error(`Invalid validator share address: ${validatorShareAddress}`)
     }
 
-    const rewards = await this.getLiquidRewards({ delegatorAddress, validatorShareAddress })
+    const [rewards] = await Promise.all([
+      this.getLiquidRewards({ delegatorAddress, validatorShareAddress }),
+      this.assertValidatorActive(validatorShareAddress)
+    ])
     if (parseEther(rewards) === 0n) {
       throw new Error('No rewards available to compound')
     }
@@ -421,7 +433,8 @@ export class PolygonStaker {
       tx: {
         to: validatorShareAddress,
         data: appendReferrerTracking(calldata, referrer),
-        value: 0n
+        value: 0n,
+        chainId: this.chain.id
       }
     }
   }
@@ -852,6 +865,31 @@ export class PolygonStaker {
         status: 'unknown',
         receipt: null
       }
+    }
+  }
+
+  private async assertValidatorActive (validatorShareAddress: Address): Promise<void> {
+    const validatorId = await this.publicClient.readContract({
+      address: validatorShareAddress,
+      abi: VALIDATOR_SHARE_ABI,
+      functionName: 'validatorId'
+    })
+
+    const validator = await this.publicClient.readContract({
+      address: this.contracts.stakeManagerAddress,
+      abi: STAKE_MANAGER_ABI,
+      functionName: 'validators',
+      args: [validatorId]
+    })
+
+    const status = Number(validator[7])
+    if (status !== 1) {
+      const statusName = VALIDATOR_STATUS[status as keyof typeof VALIDATOR_STATUS] ?? 'Unknown'
+      throw new Error(
+        `Validator is not active (status: ${statusName}). ` +
+          'The validator may be locked, inactive, or unstaked. ' +
+          'See the @chorus-one/polygon README for how to list active validators on testnet.'
+      )
     }
   }
 

--- a/packages/polygon/src/types.ts
+++ b/packages/polygon/src/types.ts
@@ -15,6 +15,14 @@ export interface Transaction {
   data: Hex
   /** The amount of ETH (in wei) to be sent with the transaction */
   value?: bigint
+  /**
+   * The chain ID where the transaction must be broadcast.
+   *
+   * Polygon staking contracts live on Ethereum L1, not on the Polygon chain itself:
+   * - mainnet: `1` (Ethereum Mainnet)
+   * - testnet: `11155111` (Sepolia)
+   */
+  chainId: number
 }
 
 export interface PolygonTxStatus {

--- a/packages/polygon/test/fixtures/expected-data.ts
+++ b/packages/polygon/test/fixtures/expected-data.ts
@@ -12,6 +12,7 @@ export const EXPECTED_APPROVE_TX = {
     to: stakingTokenAddress as Address,
     // approve(address spender, uint256 amount) with spender = stakeManagerAddress (0x5e3e...), amount = 100e18
     data: '0x095ea7b30000000000000000000000005e3ef299fddf15eaa0432e6e66473ace8c13d9080000000000000000000000000000000000000000000000056bc75e2d63100000' as Hex,
-    value: 0n
+    value: 0n,
+    chainId: 1
   }
 }

--- a/packages/polygon/test/integration/staker.spec.ts
+++ b/packages/polygon/test/integration/staker.spec.ts
@@ -93,6 +93,34 @@ describe('PolygonStaker', () => {
       const precision = await staker.getExchangeRatePrecision(validatorShareAddress)
       assert.equal(precision, EXCHANGE_RATE_HIGH_PRECISION)
     })
+
+    it('rejects staking to an unstaked validator', async () => {
+      const unstakedValidator = '0xd245710936382e5ED099d4F8D9AAE64e67e30EF3' as Address
+      await expect(
+        staker.buildStakeTx({
+          delegatorAddress: WHALE_DELEGATOR,
+          validatorShareAddress: unstakedValidator,
+          amount: '100',
+          minSharesToMint: 0n
+        })
+      ).to.be.rejectedWith('Validator is not active (status: Unstaked)')
+    })
+
+    it('allows staking to an active validator', async () => {
+      // Should not throw — the default validatorShareAddress is active
+      const allowance = await staker.getAllowance(WHALE_DELEGATOR)
+      // Will fail on allowance, not on validator status
+      if (parseEther(allowance) === 0n) {
+        await expect(
+          staker.buildStakeTx({
+            delegatorAddress: WHALE_DELEGATOR,
+            validatorShareAddress,
+            amount: '100',
+            minSharesToMint: 0n
+          })
+        ).to.be.rejectedWith('Insufficient POL allowance')
+      }
+    })
   })
 
   describe('staking lifecycle', () => {

--- a/packages/polygon/test/staker.spec.ts
+++ b/packages/polygon/test/staker.spec.ts
@@ -27,6 +27,7 @@ describe('PolygonStaker', () => {
       assert.equal(tx.to, EXPECTED_APPROVE_TX.expected.to)
       assert.equal(tx.data, EXPECTED_APPROVE_TX.expected.data)
       assert.equal(tx.value, EXPECTED_APPROVE_TX.expected.value)
+      assert.equal(tx.chainId, EXPECTED_APPROVE_TX.expected.chainId)
     })
 
     it('should generate correct unsigned approve tx for max (unlimited) amount', async () => {
@@ -47,6 +48,22 @@ describe('PolygonStaker', () => {
       await expect(staker.buildApproveTx({ amount: '0' })).to.be.rejectedWith('Amount must be greater than 0')
       await expect(staker.buildApproveTx({ amount: '' })).to.be.rejectedWith('Amount cannot be empty')
       await expect(staker.buildApproveTx({ amount: 'invalid' })).to.be.rejectedWith('Amount must be a valid number')
+    })
+  })
+
+  describe('chainId', () => {
+    it('should return mainnet chainId (1) for mainnet network', async () => {
+      const { tx } = await staker.buildApproveTx({ amount: '100' })
+      assert.equal(tx.chainId, 1)
+    })
+
+    it('should return sepolia chainId (11155111) for testnet network', async () => {
+      const testnetStaker = new PolygonStaker({
+        network: 'testnet',
+        rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com'
+      })
+      const { tx } = await testnetStaker.buildApproveTx({ amount: '100' })
+      assert.equal(tx.chainId, 11155111)
     })
   })
 


### PR DESCRIPTION
## Summary
- Update testnet ValidatorShare contract address to `0xe50f5ad9b885675fd11d8204eb01c83a8a32a91d`
- Bump `@chorus-one/polygon` version to 1.0.4
- Add `chainId` field to `Transaction` type (1 for mainnet, 11155111 for Sepolia)
- Reject stake/compound transactions targeting non-active validators with a descriptive error
- Add testnet validator listing script to README