### PR TITLE
Update Attestant API docs intro to Bitwise Onchain Solutions branding

### DIFF
--- a/book/build-your-staking-dapp/ethereum/native_staking_attestant_endpoints.md
+++ b/book/build-your-staking-dapp/ethereum/native_staking_attestant_endpoints.md
@@ -1,6 +1,6 @@
-This section provides an overview of the key API endpoints available for **Native Staking** on the Ethereum network via the **Chorus One Native Staking API**.
+This section provides an overview of the key API endpoints available for Native Staking on the Ethereum network via the Bitwise Onchain Solutions Native Staking API. Dedicated ETH staking services are provided by Attestant Ltd (d/b/a Bitwise Onchain Solutions), the parent company of Bitwise Onchain Solutions AG (f/k/a Chorus One).
 
-The Chorus One Native Staking API allows you to manage subaccounts, create validators, and monitor validator status through simple REST API calls. Below, we will explore each endpoint with practical examples to help you get started.
+The Bitwise Onchain Solutions Native Staking API allows you to manage subaccounts, create validators, and monitor validator status through simple REST API calls. Below, we will explore each endpoint with practical examples to help you get started.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

- Rebrands the Attestant API docs introduction from Chorus One Native Staking API to Bitwise Onchain Solutions Native Staking API
- Adds clarifying context about the corporate structure: Attestant Ltd (d/b/a Bitwise Onchain Solutions), parent of Bitwise Onchain Solutions AG (f/k/a Chorus One)