### PR TITLE
Add Rewards Dashboard API keys page and Getting Started section

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -99,9 +99,7 @@ Using an API for staking can sometimes introduce concerns about transparency and
 
 ## Rewards Dashboard API Keys
 
-The Chorus One SDK builds, signs, and broadcasts transactions and reads staking data directly on-chain. If you instead need programmatic access to consolidated staking **rewards data** over REST — for reporting, accounting, or monitoring dashboards — use the Chorus One Rewards API.
-
-Generate and manage your API keys in the **Chorus One Rewards Dashboard**. See the [Rewards API documentation](https://chorus-one.gitbook.io/rewards-api) for authentication details and available endpoints.
+For programmatic access to staking **rewards data** over REST, generate API keys in the **Chorus One Rewards Dashboard** and see the [Rewards API documentation](https://chorus-one.gitbook.io/rewards-api) for endpoints and authentication.
 
 ## Installation
 

--- a/book/README.md
+++ b/book/README.md
@@ -97,6 +97,12 @@ Using an API for staking can sometimes introduce concerns about transparency and
 
 - **Staking CLI** ([📦 npm package](https://www.npmjs.com/package/@chorus-one/staking-cli))
 
+## Rewards Dashboard API Keys
+
+The Chorus One SDK builds, signs, and broadcasts transactions and reads staking data directly on-chain. If you instead need programmatic access to consolidated staking **rewards data** over REST — for reporting, accounting, or monitoring dashboards — use the Chorus One Rewards API.
+
+Generate and manage your API keys in the **Chorus One Rewards Dashboard**. See the [Rewards API documentation](https://chorus-one.gitbook.io/rewards-api) for authentication details and available endpoints.
+
 ## Installation
 
 The Chorus One SDK is available as a set of npm packages and supports both Node.js and browser environments.

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -1,6 +1,7 @@
 # Table of contents
 
 - [Getting Started](README.md)
+- [Rewards Dashboard API Keys](rewards-dashboard-api-keys.md)
 
 ## Build your Staking dApp
 

--- a/book/rewards-dashboard-api-keys.md
+++ b/book/rewards-dashboard-api-keys.md
@@ -1,0 +1,5 @@
+# Rewards Dashboard API Keys
+
+The Chorus One SDK builds, signs, and broadcasts transactions and reads staking data directly on-chain. If you instead need programmatic access to consolidated staking **rewards data** over REST — for reporting, accounting, or monitoring dashboards — use the Chorus One Rewards API.
+
+Generate and manage your API keys in the **Chorus One Rewards Dashboard**. See the [Rewards API documentation](https://chorus-one.gitbook.io/rewards-api) for authentication details and available endpoints.

--- a/book/rewards-dashboard-api-keys.md
+++ b/book/rewards-dashboard-api-keys.md
@@ -1,5 +1,3 @@
 # Rewards Dashboard API Keys
 
-The Chorus One SDK builds, signs, and broadcasts transactions and reads staking data directly on-chain. If you instead need programmatic access to consolidated staking **rewards data** over REST — for reporting, accounting, or monitoring dashboards — use the Chorus One Rewards API.
-
-Generate and manage your API keys in the **Chorus One Rewards Dashboard**. See the [Rewards API documentation](https://chorus-one.gitbook.io/rewards-api) for authentication details and available endpoints.
+For programmatic access to staking **rewards data** over REST, generate API keys in the **Chorus One Rewards Dashboard** and see the [Rewards API documentation](https://chorus-one.gitbook.io/rewards-api) for endpoints and authentication.


### PR DESCRIPTION
The SDK docs had no pointer to the Chorus One Rewards API, where users generate API keys for programmatic access to rewards data. This adds that pointer so SDK users can find it.

- New `Rewards Dashboard API Keys` page registered in `SUMMARY.md` (appears in the GitBook sidebar)
- Matching section in the Getting Started page
- Both link to https://chorus-one.gitbook.io/rewards-api