### PR TITLE
Fix signing for legacy secp256k1 accounts on EVM-migrated chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10030,7 +10030,7 @@
     },
     "packages/cosmos": {
       "name": "@chorus-one/cosmos",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@chorus-one/signer": "^1.0.0",

--- a/packages/cosmos/package.json
+++ b/packages/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-one/cosmos",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "All-in-one toolkit for building staking dApps on Cosmos SDK based networks",
   "scripts": {
     "build": "rm -fr dist/* && tsc -p tsconfig.mjs.json --outDir dist/mjs && tsc -p tsconfig.cjs.json --outDir dist/cjs && bash ../../scripts/fix-package-json"

--- a/packages/cosmos/src/staker.ts
+++ b/packages/cosmos/src/staker.ts
@@ -372,14 +372,22 @@ export class CosmosStaker {
     const acc = await getAccount(cosmosClient, this.networkConfig.lcdUrl, signerAddress)
     const signDoc = await genSignableTx(this.networkConfig, chainID, tx, acc.accountNumber, acc.sequence, gas, memo)
 
-    const isEVM = this.networkConfig.isEVM ?? false
+    let isEVM = this.networkConfig.isEVM ?? false
+
+    // accounts created before a chain migrated to EVM (e.g. MANTRA v7) keep a
+    // legacy secp256k1 pubkey on-chain and the chain verifies their signatures
+    // the classic cosmos way, regardless of the chain-wide key algo
+    if (isEVM && acc.pubkey != null && !acc.pubkey.type.toLowerCase().includes('ethsecp256k1')) {
+      isEVM = false
+    }
+
     const { sig, pk } = await genSignDocSignature(signer, acc, signDoc, isEVM)
 
     const pkType = isEVM ? (acc.pubkey?.type ?? undefined) : undefined
     const signedTx = genSignedTx(signDoc, sig, pk, pkType)
 
     // IMPORTANT: verify that signer address matches derived address from signature
-    const addressFromPK = (await CosmosStaker.getAddressDerivationFn(this.networkConfig)(pk, ''))[0]
+    const addressFromPK = (await CosmosStaker.getAddressDerivationFn({ ...this.networkConfig, isEVM })(pk, ''))[0]
 
     if (addressFromPK !== signerAddress) {
       throw new Error(


### PR DESCRIPTION
Chains that migrate to EVM (e.g. MANTRA v7) flip the chain-wide key algo to ethsecp256k1, but accounts created before the migration keep a legacy secp256k1 pubkey on-chain and the chain verifies their signatures the classic cosmos way. CosmosStaker.sign now downgrades the isEVM flag per-account, so those accounts sign with sha256 amino and verify the signer address with the classic derivation instead of throwing "signer account pubkey type is not ethsecp256k1".